### PR TITLE
Send long text messages without dividing them

### DIFF
--- a/android_bridges/And_jni_Bridge.pas
+++ b/android_bridges/And_jni_Bridge.pas
@@ -1202,11 +1202,14 @@ procedure jSend_Email(env:PJNIEnv; this:jobject;
 //by jmpessoa
 function jSend_SMS(env:PJNIEnv; this:jobject;
                        toNumber: string;
-                       smessage:string): integer; overload;
+                       smessage: string;
+					   multipartMessage: Boolean): integer; overload;
 
 function jSend_SMS(env:PJNIEnv; this:jobject;
                        toNumber: string;
-                       smessage:string; packageDeliveredAction: string): integer; overload;
+                       smessage: string; 
+					   packageDeliveredAction: string;
+					   multipartMessage: Boolean): integer; overload;
 
 function jRead_SMS(env:PJNIEnv; this:jobject; intentReceiver: jObject; addressBodyDelimiter: string): string;  //message
 
@@ -10335,16 +10338,18 @@ end;
 //by jmpessoa
 function jSend_SMS(env:PJNIEnv; this:jobject;
                        toNumber: string;
-                       smessage:string): integer;
+                       smessage: string;
+					   multipartMessage: Boolean): integer;
 var
  _jMethod : jMethodID = nil;
- _jParams : array[0..1] of jValue;
+ _jParams : array[0..2] of jValue;
  jCls: jClass=nil;
 begin
  jCls:= Get_gjClass(env);
- _jMethod:= env^.GetMethodID(env, jCls, 'jSend_SMS', '(Ljava/lang/String;Ljava/lang/String;)I');
+ _jMethod:= env^.GetMethodID(env, jCls, 'jSend_SMS', '(Ljava/lang/String;Ljava/lang/String;Z)I');
  _jParams[0].l := env^.NewStringUTF(env, pchar(toNumber) );
  _jParams[1].l := env^.NewStringUTF(env, pchar(smessage) );
+ _jParams[2].z := JBool(multipartMessage);
  Result:= env^.CallIntMethodA(env,this,_jMethod,@_jParams);
  env^.DeleteLocalRef(env,_jParams[0].l);
  env^.DeleteLocalRef(env,_jParams[1].l);
@@ -10352,17 +10357,20 @@ end;
 
 function jSend_SMS(env:PJNIEnv; this:jobject;
                        toNumber: string;
-                       smessage:string; packageDeliveredAction: string): integer;
+                       smessage: string; 
+					   packageDeliveredAction: string;
+					   multipartMessage: Boolean): integer;
 var
  _jMethod : jMethodID = nil;
- _jParams : array[0..2] of jValue;
+ _jParams : array[0..3] of jValue;
  jCls: jClass=nil;
 begin
  jCls:= Get_gjClass(env);
- _jMethod:= env^.GetMethodID(env, jCls, 'jSend_SMS', '(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)I');
+ _jMethod:= env^.GetMethodID(env, jCls, 'jSend_SMS', '(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)I');
  _jParams[0].l := env^.NewStringUTF(env, pchar(toNumber) );
  _jParams[1].l := env^.NewStringUTF(env, pchar(smessage) );
  _jParams[2].l := env^.NewStringUTF(env, pchar(packageDeliveredAction) );
+ _jParams[3].z := JBool(multipartMessage);
  Result:= env^.CallIntMethodA(env,this,_jMethod,@_jParams);
  env^.DeleteLocalRef(env,_jParams[0].l);
  env^.DeleteLocalRef(env,_jParams[1].l);

--- a/android_bridges/Laz_And_Controls.pas
+++ b/android_bridges/Laz_And_Controls.pas
@@ -390,12 +390,12 @@ type
    constructor Create(AOwner: TComponent); override;
    destructor Destroy; override;
    procedure Init(refApp: jApp) override;
-   function Send: integer; overload;
+   function Send(multipartMessage: Boolean = False): integer; overload;
 
-   function Send(toNumber: string;  msg: string): integer; overload;
-   function Send(toNumber: string;  msg: string; packageDeliveredAction: string): integer; overload;
+   function Send(toNumber: string;  msg: string; multipartMessage: Boolean = False): integer; overload;
+   function Send(toNumber: string;  msg: string; packageDeliveredAction: string; multipartMessage: Boolean = False): integer; overload;
 
-   function Send(toName: string): integer; overload;
+   function Send(toName: string; multipartMessage: Boolean = False): integer; overload;
 
 
    function Read(intentReceiver: jObject; addressBodyDelimiter: string): string;
@@ -6657,7 +6657,7 @@ begin
   FSMSMessage.Assign(Value);
 end;
 
-function jSMS.Send: integer;
+function jSMS.Send(multipartMessage: Boolean): integer;
 begin
   if FInitialized then
   begin
@@ -6666,11 +6666,12 @@ begin
     if FMobileNumber <> '' then
         Result:= jSend_SMS(gApp.Jni.jEnv, gApp.Jni.jThis,
                   FMobileNumber,     //to
-                  FSMSMessage.Text);  //message
+                  FSMSMessage.Text,  //message
+				  multipartMessage);
   end;
 end;
 
-function jSMS.Send(toName: string): integer;
+function jSMS.Send(toName: string; multipartMessage: Boolean): integer;
 begin
   if FInitialized then
   begin
@@ -6680,29 +6681,33 @@ begin
     if FMobileNumber <> '' then
         Result:= jSend_SMS(gApp.Jni.jEnv, gApp.Jni.jThis,
                   FMobileNumber,     //to
-                  FSMSMessage.Text);  //message
+                  FSMSMessage.Text,  //message
+				  multipartMessage);
   end;
 end;
 
-function jSMS.Send(toNumber: string;  msg: string): integer;
+function jSMS.Send(toNumber: string;  msg: string; multipartMessage: Boolean): integer;
 begin
  if FInitialized then
  begin
     if toNumber <> '' then
         Result:= jSend_SMS(gApp.Jni.jEnv, gApp.Jni.jThis,
                   toNumber,     //to
-                  msg);  //message
+                  msg,  //message
+				  multipartMessage);
   end;
 end;
 
-function jSMS.Send(toNumber: string;  msg: string; packageDeliveredAction: string): integer;
+function jSMS.Send(toNumber: string;  msg: string; packageDeliveredAction: string; multipartMessage: Boolean): integer;
 begin
  if FInitialized then
  begin
     if toNumber <> '' then
         Result:= jSend_SMS(gApp.Jni.jEnv, gApp.Jni.jThis,
                   toNumber,     //to
-                  msg, packageDeliveredAction);  //message
+                  msg,  //message
+				  packageDeliveredAction,
+				  multipartMessage);
   end;
 end;
 

--- a/java/Controls.java
+++ b/java/Controls.java
@@ -1751,36 +1751,50 @@ public void jSend_Email(
 //http://codetheory.in/android-sms/
 //http://www.developerfeed.com/java/tutorial/sending-sms-using-android
 //http://www.techrepublic.com/blog/software-engineer/how-to-send-a-text-message-from-within-your-android-app/
-public int jSend_SMS(String phoneNumber, String msg) {
+public int jSend_SMS(String phoneNumber, String msg, boolean multipartMessage) {
 	SmsManager sms = SmsManager.getDefault();	
 	try {
-	      //SmsManager.getDefault().sendTextMessage(phoneNumber, null, msg, null, null);	      
-	      List<String> messages = sms.divideMessage(msg);    
-	      for (String message : messages) {
-	          sms.sendTextMessage(phoneNumber, null, message, null, null);
-	      }	      
-	      //Log.i("Send_SMS",phoneNumber+": "+ msg);
-	      return 1; //ok	      
-	  }catch (Exception e) {
-		  //Log.i("Send_SMS Fail",e.toString());
-	      return 0; //fail
-	  }
+		//SmsManager.getDefault().sendTextMessage(phoneNumber, null, msg, null, null);
+		if (multipartMessage) {
+			ArrayList<String> messages = sms.divideMessage(msg);    
+			sms.sendMultipartTextMessage(phoneNumber, null, messages, null, null);			  
+		} else {
+			List<String> messages = sms.divideMessage(msg);    
+			for (String message : messages) {
+				sms.sendTextMessage(phoneNumber, null, message, null, null);
+			}			    
+		}
+		//Log.i("Send_SMS",phoneNumber+": "+ msg);
+		return 1; //ok	      
+	} catch (Exception e) {
+		//Log.i("Send_SMS Fail",e.toString());
+		return 0; //fail
+	}
 }
 
-public int jSend_SMS(String phoneNumber, String msg, String packageDeliveredAction) {	
+public int jSend_SMS(String phoneNumber, String msg, String packageDeliveredAction, boolean multipartMessage) {	
 	String SMS_DELIVERED = packageDeliveredAction;
 	PendingIntent deliveredPendingIntent = PendingIntent.getBroadcast(this.GetContext(), 0, new Intent(SMS_DELIVERED), 0);
 	SmsManager sms = SmsManager.getDefault();
 	try {
-	      //SmsManager.getDefault().sendTextMessage(phoneNumber, null, msg, null, deliveredPendingIntent);
-	      //Log.i("Send_SMS",phoneNumber+": "+ msg);
-	      List<String> messages = sms.divideMessage(msg);    
-	      for (String message : messages) {
-	          sms.sendTextMessage(phoneNumber, null, message, null, deliveredPendingIntent);
-	      }	      
-	      return 1; //ok	      
-	}catch (Exception e) {
-	      return 0; //fail
+		//SmsManager.getDefault().sendTextMessage(phoneNumber, null, msg, null, deliveredPendingIntent);
+		if (multipartMessage) {
+			ArrayList<String> messages = sms.divideMessage(msg);    
+			ArrayList<PendingIntent> deliveredPendingIntents = new ArrayList<PendingIntent>();
+			for (int i = 0; i < messages.size(); i++) {
+				deliveredPendingIntents.add(i, deliveredPendingIntent);
+			}			
+			sms.sendMultipartTextMessage(phoneNumber, null, messages, null, deliveredPendingIntents);			  
+		} else {
+			List<String> messages = sms.divideMessage(msg);    
+			for (String message : messages) {
+				sms.sendTextMessage(phoneNumber, null, message, null, deliveredPendingIntent);
+			}			    
+		}	
+		//Log.i("Send_SMS",phoneNumber+": "+ msg);    
+		return 1; //ok	      
+	} catch (Exception e) {
+		return 0; //fail
 	}
 }
 


### PR DESCRIPTION
New parameter `multipartMessage` in `jSMS` class methods for sending SMS:
```
function Send(multipartMessage: Boolean = False): integer; overload;

function Send(toNumber: string;  msg: string; multipartMessage: Boolean = False): integer; overload;
function Send(toNumber: string;  msg: string; packageDeliveredAction: string; multipartMessage: Boolean = False): integer; overload;

function Send(toName: string; multipartMessage: Boolean = False): integer; overload;
```

Allows sending long SMS messages as a single one (visually), without dividing them after reaching text limit (160 characters).

`multipartMessage` set to False:
![multi_false](https://user-images.githubusercontent.com/13695767/30481517-7279233a-9a1f-11e7-889f-14b87fea0032.png)
True:
![multi_true](https://user-images.githubusercontent.com/13695767/30481514-6f9f56fc-9a1f-11e7-80c3-7e842cc0738d.png)

Default: False (old behavior).
