### PR TITLE
Global self-assignment of Id [by TR3E]

### DIFF
--- a/android_bridges/And_jni_Bridge.pas
+++ b/android_bridges/And_jni_Bridge.pas
@@ -767,7 +767,6 @@ procedure jWebView_LoadDataWithBaseURL(env: PJNIEnv; _jwebview: JObject; _s1,_s2
 function  jWebView_getWidth(env:PJNIEnv; _jwebview : jObject): integer; //LMB
 function  jWebView_getHeight(env:PJNIEnv; _jwebview : jObject ): integer; //LMB
 
-
 // Canvas
 Function  jCanvas_Create               (env:PJNIEnv;
                                         this:jobject; SelfObj : TObject) : jObject;
@@ -1083,7 +1082,7 @@ procedure jDBListView_AddLParamsParentRule(env: PJNIEnv; _jdblistview: JObject;
  _rule: integer);
 procedure jDBListView_SetLayoutAll(env: PJNIEnv; _jdblistview: JObject; _idAnchor: integer);
 procedure jDBListView_ClearLayoutAll(env: PJNIEnv; _jdblistview: JObject);
-procedure jDBListView_SetId(env: PJNIEnv; _jdblistview: JObject; _id: integer);
+procedure jDBListView_setId(env: PJNIEnv; _jdblistview: JObject; _id: integer);
 function jDBListView_GetItemIndex(env: PJNIEnv; _jdblistview: JObject): integer;
 function jDBListView_GetItemCaption(env: PJNIEnv; _jdblistview: JObject): string;
 procedure jDBListView_SetSelection(env: PJNIEnv; _jdblistview: JObject; _index: integer);
@@ -11746,7 +11745,7 @@ end;
    end;
 
 
-   procedure jDBListView_SetId(env: PJNIEnv; _jdblistview: JObject; _id: integer);
+   procedure jDBListView_setId(env: PJNIEnv; _jdblistview: JObject; _id: integer);
    var
      jParams: array[0..0] of jValue;
      jMethod: jMethodID = nil;
@@ -11754,7 +11753,7 @@ end;
    begin
      jParams[0].i := _id;
      jCls := env^.GetObjectClass(env, _jdblistview);
-     jMethod := env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+     jMethod := env^.GetMethodID(env, jCls, 'setId', '(I)V');
      env^.CallVoidMethodA(env, _jdblistview, jMethod, @jParams);
      env^.DeleteLocalRef(env, jCls);
    end;

--- a/android_bridges/Laz_And_Controls.pas
+++ b/android_bridges/Laz_And_Controls.pas
@@ -878,7 +878,6 @@ type
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
 
-    procedure SetId(_id: integer);
     function GetItemIndex(): integer;
     function GetItemCaption(): string;
     procedure SetSelection(_index: integer);
@@ -1874,7 +1873,7 @@ type
     procedure GoForward();
     procedure ScrollTo(_x, _y: integer);//by MB:
 
-	//LMB
+    //LMB
     function  ScrollY: integer;//LMB
     procedure LoadDataWithBaseURL(s1,s2,s3,s4,s5: string);//LMB
     procedure FindAll(_s: string); //LMB:
@@ -1882,7 +1881,6 @@ type
     procedure ClearMatches();//LMB
     function GetFindIndex: integer;//LMB
     function GetFindCount: integer;//LMB
-    property OnFindResult: TOnWebViewFindResult read FOnFindResult write FOnFindResult;
     function GetWidth: integer;  override;//LMB
     function GetHeight: integer; override;//LMB
 
@@ -1894,6 +1892,8 @@ type
     // Event
     property OnStatus  : TOnWebViewStatus read FOnStatus   write FOnStatus;
     property OnLongClick: TOnNotify read FOnLongClick write FOnLongClick;
+    property OnFindResult: TOnWebViewFindResult read FOnFindResult write FOnFindResult;
+
   end;
 
   jCanvas = class(jControl)
@@ -3495,7 +3495,6 @@ begin
   pasWebView.OnFindResult(pasWebView,findIndex,findCount);
 end;
 
-
 {
 procedure Java_Event_pOnAsyncEvent(env: PJNIEnv; this: jobject;
                                       Obj: TObject; EventType,Progress : integer);
@@ -3764,6 +3763,9 @@ constructor jTextView.Create(AOwner: TComponent);
 begin
 
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+
   FTextAlignment:= taLeft;
   FText:= '';
 
@@ -4234,6 +4236,9 @@ end;
 constructor jEditText.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+
   FText:='';
   //FColor:= colbrDefault; //colbrWhite;
   FOnLostFocus:= nil;
@@ -4971,6 +4976,9 @@ end;
 constructor jButton.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+
   FText:= '';
   FMarginLeft   := 5;
   FMarginTop    := 5;
@@ -5319,6 +5327,9 @@ end;
 constructor jCheckBox.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+
   FText      := '';
   FChecked   := False;
   FMarginLeft   := 5;
@@ -5566,6 +5577,9 @@ end;
 constructor jRadioButton.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+
   FText      := '';
   FChecked   := False;
   FMarginLeft   := 5;
@@ -5625,12 +5639,6 @@ begin
    begin
     jRadioButton_setParent2(FjEnv, FjObject , FjPRLayout);
    end;
-
-   // tk
-   if (Self.Id = 0) or Self.IDExistsInParent then
-    Self.AssignNewId;
-   //if  Self.Id = 0 then Self.Id:= Random(10000000);
-   // end tk
 
    jRadioButton_setId(FjEnv, FjObject , Self.Id);
   end;
@@ -5836,6 +5844,9 @@ end;
 constructor jProgressBar.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+
   FProgress  := 0;
   FMax       := 100;  //default...
   FStyle     := cjProgressBarStyleHorizontal;
@@ -6058,6 +6069,9 @@ end;
 constructor jImageView.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+
   // Init
   FImageName:= '';
   FImageIndex:= -1;
@@ -7582,6 +7596,8 @@ constructor jListView.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
 
+  if gapp <> nil then FId := gapp.GetNewId();
+
   FWidgetItem:= wgNone;
   FDelimiter:= '|';
   FTextDecorated:= txtNormal;
@@ -8385,7 +8401,7 @@ begin
   Result:= jListView_getLParamHeight(FjEnv, FjObject );
 
   if Result = -1 then //lpMatchParent
-    Result := sysGetHeightOfParent(FParent);
+   Result := sysGetHeightOfParent(FParent);
 end;
 
 function jListView.GetTotalHeight: integer;
@@ -8718,6 +8734,9 @@ end;
 constructor jScrollView.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+
   FScrollSize := 800; //to scrolling images this number could be higher....
   FLParamWidth:= lpMatchParent;
   FLParamHeight:= lpWrapContent;
@@ -8988,6 +9007,9 @@ end;
 Constructor jHorizontalScrollView.Create(AOwner: TComponent);
  begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+
   FScrollSize := 800; //to scrolling images this number could be higher....
 
   FLParamWidth:= lpMatchParent;
@@ -9221,6 +9243,9 @@ end;
 constructor jWebView.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+
   FJavaScript:= True;
   FZoomControl:= True;
   FOnStatus:= nil;
@@ -9263,10 +9288,10 @@ begin
   end;
 
   jWebView_setLeftTopRightBottomWidthHeight(FjEnv, FjObject ,
-    FMarginLeft,FMarginTop,FMarginRight,FMarginBottom,
-    sysGetLayoutParams( FWidth, FLParamWidth, Self.Parent, sdW, fmarginLeft + fmarginRight ),
-    sysGetLayoutParams( FHeight, FLParamHeight, Self.Parent, sdH, fMargintop + fMarginbottom ));
-
+                                           FMarginLeft,FMarginTop,FMarginRight,FMarginBottom,
+                                           sysGetLayoutParams( FWidth, FLParamWidth, Self.Parent, sdW, fmarginLeft + fmarginRight ),
+                                           sysGetLayoutParams( FHeight, FLParamHeight, Self.Parent, sdH, fMargintop + fMarginbottom ));
+                  
   jWebView_SetZoomControl(FjEnv, FjObject, FZoomControl);
 
   for rToA := raAbove to raAlignRight do
@@ -9315,20 +9340,20 @@ begin
   // jWebView_RemoveFromViewParent(FjEnv, FjObject);
 end;
 
-procedure jWebView.SetColor(Value: TARGBColorBridge);
+Procedure jWebView.SetColor(Value: TARGBColorBridge);
 begin
   FColor := Value;
   if (FInitialized = True) and (FColor <> colbrDefault) then
      View_SetBackGroundColor(FjEnv, FjObject , GetARGB(FCustomColor, FColor));
 end;
 
-procedure jWebView.Refresh;
+Procedure jWebView.Refresh;
  begin
   if not FInitialized then Exit;
   View_Invalidate(FjEnv, FjObject );
  end;
 
-procedure jWebView.SetJavaScript(Value: Boolean);
+Procedure jWebView.SetJavaScript(Value : Boolean);
 begin
   FJavaScript:= Value;
   if FInitialized then
@@ -9344,14 +9369,13 @@ begin
   end;
 end;
 
-procedure jWebView.Navigate(url: string);
+Procedure jWebView.Navigate(url: string);
 begin
   if not FInitialized then Exit;
   jWebView_loadURL(FjEnv, FjObject , url);
 end;
 
-procedure jWebView.LoadFromHtmlFile(environmentDirectoryPath: string;
-  htmlFileName: string);
+Procedure jWebView.LoadFromHtmlFile(environmentDirectoryPath: string; htmlFileName: string);
 begin;
    Navigate('file://'+environmentDirectoryPath+'/'+htmlFileName);
 end;
@@ -9405,7 +9429,7 @@ begin
      jWebView_GoForward(FjEnv, FjObject);
 end;
 
-procedure jWebView.ClearLayout;
+procedure jWebView.ClearLayout();
 var
   rToP: TPositionRelativeToParent;
   rToA: TPositionRelativeToAnchorID;
@@ -9458,7 +9482,6 @@ begin
   if FInitialized then
      jWebView_ScrollTo(FjEnv, FjObject, _x, _y);
 end;
-
 
 //LMB
 function jWebView.ScrollY: integer;
@@ -10440,6 +10463,9 @@ end;
 constructor jView.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+
   FMouches.Mouch.Active := False;
   FMouches.Mouch.Start  := False;
   FMouches.Mouch.Zoom   := 1.0;
@@ -10939,6 +10965,9 @@ end;
 Constructor jImageBtn.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+
   FImageUpName:='';
   FImageDownName:='';
   FImageUpIndex:= -1;
@@ -11351,6 +11380,9 @@ end;
 constructor jGLViewEvent.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+
   FOnGLCreate  := nil;
   FOnGLChange  := nil;
   FOnGLDraw    := nil;
@@ -12142,6 +12174,9 @@ end;
 constructor jPanel.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+
   FLParamWidth:= lpMatchParent;
   FLParamHeight:=lpWrapContent;
   FAcceptChildrenAtDesignTime:= True;
@@ -12564,6 +12599,9 @@ constructor jDBListView.Create(AOwner: TComponent);
 
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+
   FMarginLeft := 10;
   FMarginTop := 10;
   FMarginBottom := 10;
@@ -12642,7 +12680,7 @@ begin
    FjPRLayoutHome:= FjPRLayout;
 
    jDBListView_SetViewParent(FjEnv, FjObject, FjPRLayout);
-   jDBListView_SetId(FjEnv, FjObject, Self.Id);
+   jDBListView_setId(FjEnv, FjObject, Self.Id);
   end;
 
   jDBListView_setLeftTopRightBottomWidthHeight(FjEnv, FjObject ,
@@ -12928,12 +12966,6 @@ begin
   end;
 end;
 
-procedure jDBListView.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-    jDBListView_SetId(FjEnv, FjObject, _id);
-end;
 {
 procedure jDBListView.UpdateView();
 begin

--- a/android_bridges/analogclock.pas
+++ b/android_bridges/analogclock.pas
@@ -39,7 +39,6 @@ jAnalogClock = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure SetLGravity(_value: TLayoutGravity);
 
  published
@@ -72,6 +71,9 @@ implementation
 constructor jAnalogClock.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+
   FMarginLeft   := 10;
   FMarginTop    := 10;
   FMarginBottom := 10;
@@ -288,13 +290,6 @@ begin
   end;
 end;
 
-procedure jAnalogClock.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jAnalogClock_SetId(FjEnv, FjObject, _id);
-end;
-
 procedure jAnalogClock.SetLGravity(_value: TLayoutGravity);
 begin
   //in designing component state: set value here...
@@ -488,7 +483,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _janalogclock);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _janalogclock, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/autocompletetextview.pas
+++ b/android_bridges/autocompletetextview.pas
@@ -57,7 +57,6 @@ jAutoTextView = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     function GetItemIndex(): integer;
 
     procedure SetText(_text: string); override;
@@ -183,6 +182,8 @@ implementation
 constructor jAutoTextView.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
 
   FMarginBottom := 5;
   FMarginLeft   := 5;
@@ -430,13 +431,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jAutoTextView_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jAutoTextView.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jAutoTextView_SetId(FjEnv, FjObject, _id);
 end;
 
 function jAutoTextView.GetItemIndex(): integer;
@@ -911,7 +905,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jAutoTextView);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jAutoTextView, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/calendarview.pas
+++ b/android_bridges/calendarview.pas
@@ -56,7 +56,6 @@ jCalendarView = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure SetFirstDayOfWeek(_firstDayOfWeek: integer);
     function GetFirstDayOfWeek(): integer;
 
@@ -131,6 +130,9 @@ implementation
 constructor jCalendarView.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 10;
   FMarginTop    := 10;
   FMarginBottom := 10;
@@ -382,26 +384,6 @@ begin
 end;
 
 procedure jCalendarView.ClearLayout();
-var
-  rToP: TPositionRelativeToParent;
-  rToA: TPositionRelativeToAnchorID;
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-  begin
-     jCalendarView_clearLayoutAll(FjEnv, FjObject);
-
-     for rToP := rpBottom to rpCenterVertical do
-        if rToP in FPositionRelativeToParent then
-          jCalendarView_addlParamsParentRule(FjEnv, FjObject , GetPositionRelativeToParent(rToP));
-
-     for rToA := raAbove to raAlignRight do
-       if rToA in FPositionRelativeToAnchor then
-         jCalendarView_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
-  end;
-end;
-
-procedure jCalendarView.SetId(_id: integer);
 var
   rToP: TPositionRelativeToParent;
   rToA: TPositionRelativeToAnchorID;
@@ -774,7 +756,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jcalendarview);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jcalendarview, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/chronometer.pas
+++ b/android_bridges/chronometer.pas
@@ -45,7 +45,6 @@ jChronometer = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure SetBaseElapsedRealtime();  overload;
     procedure SetBaseElapsedRealtime(_elapsedMillis: int64); overload;
     function GetElapsedTimeMillis(): int64;
@@ -98,6 +97,9 @@ implementation
 constructor jChronometer.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 10;
   FMarginTop    := 10;
   FMarginBottom := 10;
@@ -313,13 +315,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jChronometer_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jChronometer.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jChronometer_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jChronometer.SetBaseElapsedRealtime();
@@ -563,7 +558,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jchronometer);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jchronometer, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/comboedittext.pas
+++ b/android_bridges/comboedittext.pas
@@ -62,7 +62,6 @@ jComboEditText = class(jVisualControl)
     procedure SetLayoutAll(idAnchor: integer);
     procedure ClearLayout();
     function GetView(): jObject; override;
-    procedure SetId(_id: integer);
     function GetItemIndex(): integer;
     procedure SetText(_text: string); override;
     function GetText(): string;  override;
@@ -207,6 +206,8 @@ constructor jComboEditText.Create(AOwner: TComponent);
 begin
 
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
 
   FMarginBottom := 5;
   FMarginLeft   := 5;
@@ -513,13 +514,6 @@ begin
   //in designing component state: result value here...
   if FInitialized then
    Result:= jComboEditText_GetView(FjEnv, FjObject);
-end;
-
-procedure jComboEditText.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jComboEditText_SetId(FjEnv, FjObject, _id);
 end;
 
 function jComboEditText.GetItemIndex(): integer;
@@ -1120,7 +1114,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jcomboedittext);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jcomboedittext, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/copenmapview.pas
+++ b/android_bridges/copenmapview.pas
@@ -62,7 +62,6 @@ jcOpenMapView = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayoutAll();
-    procedure SetId(_id: integer);
     procedure SetZoom(_zoom: integer);
     //function GetZoom(): integer;
     procedure SetShowScale(_show: boolean);
@@ -257,6 +256,9 @@ implementation
 constructor jcOpenMapView.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 5;
   FMarginTop    := 5;
   FMarginBottom := 5;
@@ -515,13 +517,6 @@ begin
   //in designing component state: set value here...
   if FInitialized then
      jcOpenMapView_ClearLayoutAll(FjEnv, FjObject);
-end;
-
-procedure jcOpenMapView.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jcOpenMapView_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jcOpenMapView.SetZoom(_zoom: integer);
@@ -1220,7 +1215,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jcopenmapview);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jcopenmapview, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/csignaturepad.pas
+++ b/android_bridges/csignaturepad.pas
@@ -57,8 +57,7 @@ jcSignaturePad = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayoutAll();
-    procedure SetId(_id: integer);
-
+    
     procedure SaveToGalleryJPG(_fileName: string); overload;
     procedure SaveToGalleryJPG(); overload;
     procedure Clear();
@@ -126,6 +125,9 @@ implementation
 constructor jcSignaturePad.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 10;
   FMarginTop    := 10;
   FMarginBottom := 10;
@@ -400,13 +402,6 @@ begin
   //in designing component state: set value here...
   if FInitialized then
      jcSignaturePad_ClearLayoutAll(FjEnv, FjObject);
-end;
-
-procedure jcSignaturePad.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jcSignaturePad_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jcSignaturePad.SaveToGalleryJPG(_fileName: string);
@@ -727,7 +722,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jcsignaturepad);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jcsignaturepad, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/customcamera.pas
+++ b/android_bridges/customcamera.pas
@@ -63,7 +63,6 @@ jCustomCamera = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure TakePicture(); overload;
     procedure TakePicture(_filename: string); overload;
 
@@ -126,6 +125,9 @@ implementation
 constructor jCustomCamera.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 10;
   FMarginTop    := 10;
   FMarginBottom := 10;
@@ -397,13 +399,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jCustomCamera_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jCustomCamera.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jCustomCamera_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jCustomCamera.TakePicture();
@@ -712,7 +707,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jcustomcamera);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jcustomcamera, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/customdialog.pas
+++ b/android_bridges/customdialog.pas
@@ -51,7 +51,6 @@ type
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure Show(); overload;
     procedure Show(_title: string); overload;
     procedure Show(_title: string; _iconIdentifier: string); overload;
@@ -112,6 +111,9 @@ implementation
 constructor jCustomDialog.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 10;
   FMarginTop    := 10;
   FMarginBottom := 10;
@@ -345,13 +347,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jCustomDialog_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jCustomDialog.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jCustomDialog_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jCustomDialog.Show();
@@ -626,7 +621,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jcustomdialog);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jcustomdialog, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/dblistview.pas
+++ b/android_bridges/dblistview.pas
@@ -64,7 +64,6 @@ type
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure UpdateView;
     //procedure SetItemsLayout(_value: integer);
     function GetItemIndex(): integer;
@@ -139,6 +138,9 @@ constructor jDBListView.Create(AOwner: TComponent);
 
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft := 10;
   FMarginTop := 10;
   FMarginBottom := 10;
@@ -465,13 +467,6 @@ begin
   end;
 end;
 
-procedure jDBListView.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-    jDBListView_SetId(FjEnv, FjObject, _id);
-end;
-
 procedure jDBListView.UpdateView();
 begin
   //in designing component state: set value here...
@@ -781,7 +776,7 @@ var
 begin
   jParams[0].i := _id;
   jCls := env^.GetObjectClass(env, _jdblistview);
-  jMethod := env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod := env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jdblistview, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/digitalclock.pas
+++ b/android_bridges/digitalclock.pas
@@ -40,7 +40,6 @@ jDigitalClock = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure SetFontSize(_size: DWord);
     procedure SetFontSizeUnit(_unit: TFontSizeUnit);
     procedure SetLGravity(_value: TLayoutGravity);
@@ -81,6 +80,9 @@ implementation
 constructor jDigitalClock.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 10;
   FMarginTop    := 10;
   FMarginBottom := 10;
@@ -305,13 +307,6 @@ begin
   end;
 end;
 
-procedure jDigitalClock.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jDigitalClock_SetId(FjEnv, FjObject, _id);
-end;
-
 procedure jDigitalClock.SetFontSize(_size: DWord);
 begin
   //in designing component state: set value here...
@@ -528,7 +523,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jdigitalclock);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jdigitalclock, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/drawingview.pas
+++ b/android_bridges/drawingview.pas
@@ -71,7 +71,6 @@ jDrawingView = class(jVisualControl)    //jDrawingView
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     function GetDrawingCache(): jObject;
     function GetImage(): jObject;
 
@@ -377,6 +376,8 @@ constructor jDrawingView.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
 
+  if gapp <> nil then FId := gapp.GetNewId();
+
   FMarginLeft   := 10;
   FMarginTop    := 10;
   FMarginBottom := 10;
@@ -634,13 +635,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jDrawingView_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jDrawingView.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jDrawingView_SetId(FjEnv, FjObject, _id);
 end;
 
 function jDrawingView.GetDrawingCache(): jObject;
@@ -1579,7 +1573,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jdrawingview);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jdrawingview, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/expandablelistview.pas
+++ b/android_bridges/expandablelistview.pas
@@ -77,8 +77,7 @@ jExpandableListView = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
-
+    
     procedure Add(_header: string; _delimitedChildItems: string); overload;
     procedure Add(_delimitedItem: string; _headerDelimiter: string; _childInnerDelimiter: string); overload;
 
@@ -186,6 +185,8 @@ implementation
 constructor jExpandableListView.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
 
   FHeight       := 96; //??
   FWidth        := 200; //??
@@ -489,14 +490,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jExpandableListView_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jExpandableListView.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  Fid := _id;
-  if FInitialized then
-     jExpandableListView_SetId(FjEnv, FjObject, _id);
 end;
 
 Procedure jExpandableListView.SetFontColor(_color: TARGBColorBridge);
@@ -957,7 +950,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jexpandablelistview);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jexpandablelistview, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/framelayout.pas
+++ b/android_bridges/framelayout.pas
@@ -45,8 +45,7 @@ jFrameLayout = class(jVisualControl)
     procedure AddLParamsAnchorRule(_rule: integer);
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
-    procedure SetId(_id: integer);
-
+    
  published
     property BackgroundColor: TARGBColorBridge read FColor write SetColor;
     property OnClick: TOnNotify read FOnClick write FOnClick;
@@ -80,6 +79,9 @@ implementation
 constructor jFrameLayout.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 10;
   FMarginTop    := 10;
   FMarginBottom := 10;
@@ -336,13 +338,6 @@ begin
   end;
 end;
 
-procedure jFrameLayout.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jFrameLayout_SetId(FjEnv, FjObject, _id);
-end;
-
 {-------- jFrameLayout_JNI_Bridge ----------}
 
 function jFrameLayout_jCreate(env: PJNIEnv;_Self: int64; this: jObject): jObject;
@@ -592,7 +587,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jframelayout);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jframelayout, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/gl2surfaceview.pas
+++ b/android_bridges/gl2surfaceview.pas
@@ -67,7 +67,6 @@ jGL2SurfaceView = class(jVisualControl)
     procedure AddLParamsAnchorRule(_rule: integer);
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
-    procedure SetId(_id: integer);
     procedure Pause();
     procedure Resume();
     function GetByteBufferFromByteArray(var _values: TDynArrayOfJByte): jObject;
@@ -174,6 +173,9 @@ implementation
 constructor jGL2SurfaceView.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FHeight       := 96; //??
   FWidth        := 100; //??
   FLParamWidth  := lpMatchParent;  //lpWrapContent
@@ -418,13 +420,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jGL2SurfaceView_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jGL2SurfaceView.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jGL2SurfaceView_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jGL2SurfaceView.Pause();
@@ -886,7 +881,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jgl2surfaceview);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jgl2surfaceview, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/gridview.pas
+++ b/android_bridges/gridview.pas
@@ -101,7 +101,6 @@ type
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure SetNumColumns(_value: integer);
     procedure SetColumnWidth(_value: integer);
     procedure Clear();
@@ -209,6 +208,9 @@ constructor jGridView.Create(AOwner: TComponent);
 
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft := 10;
   FMarginTop := 10;
   FMarginBottom := 10;
@@ -518,13 +520,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jGridView_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jGridView.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-    jGridView_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jGridView.AddInternal(_item: string; _imgIdentifier: string);
@@ -1170,7 +1165,7 @@ var
 begin
   jParams[0].i := _id;
   jCls := env^.GetObjectClass(env, _jgridview);
-  jMethod := env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod := env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jgridview, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/linearlayout.pas
+++ b/android_bridges/linearlayout.pas
@@ -48,7 +48,6 @@ jLinearLayout = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
 
-    procedure SetId(_id: integer);
     procedure SetOrientation(_orientation: TLinearLayoutOrientation);
 
  published
@@ -87,6 +86,9 @@ implementation
 constructor jLinearLayout.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 0;
   FMarginTop    := 0;
   FMarginBottom := 0;
@@ -353,13 +355,6 @@ begin
   end;
 end;
 
-procedure jLinearLayout.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jLinearLayout_SetId(FjEnv, FjObject, _id);
-end;
-
 procedure jLinearLayout.SetOrientation(_orientation: TLinearLayoutOrientation);
 begin
   //in designing component state: set value here...
@@ -617,7 +612,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jlinearlayout);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jlinearlayout, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/radiogroup.pas
+++ b/android_bridges/radiogroup.pas
@@ -45,7 +45,6 @@ jRadioGroup = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure Check(_id: integer);
     procedure ClearCheck();
     function GetCheckedRadioButtonId(): integer;
@@ -115,6 +114,9 @@ implementation
 constructor jRadioGroup.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 10;
   FMarginTop    := 10;
   FMarginBottom := 10;
@@ -343,13 +345,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jRadioGroup_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jRadioGroup.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jRadioGroup_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jRadioGroup.Check(_id: integer);
@@ -670,7 +665,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jradiogroup);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jradiogroup, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/ratingbar.pas
+++ b/android_bridges/ratingbar.pas
@@ -50,7 +50,6 @@ jRatingBar = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     function GetRating(): single;
     procedure SetRating(_rating: single);
     procedure SetNumStars(_numStars: integer);
@@ -105,6 +104,9 @@ implementation
 constructor jRatingBar.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+
   FMarginLeft   := 10;
   FMarginTop    := 10;
   FMarginBottom := 10;
@@ -338,14 +340,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jRatingBar_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jRatingBar.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  FId:= _id;
-  if FInitialized then
-     jRatingBar_SetId(FjEnv, FjObject, _id);
 end;
 
 function jRatingBar.GetRating(): single;
@@ -605,7 +599,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jratingbar);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jratingbar, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/sadmob.pas
+++ b/android_bridges/sadmob.pas
@@ -68,8 +68,7 @@ jsAdMob = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
-
+    
  published
 
     property BackgroundColor: TARGBColorBridge read FColor write SetColor;
@@ -92,6 +91,9 @@ implementation
 constructor jsAdMob.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 0;
   FMarginTop    := 0;
   FMarginBottom := 0;
@@ -135,7 +137,8 @@ begin
    FjPRLayoutHome:= FjPRLayout;
 
    SetViewParent( FjPRLayout );
-   SetId(Self.Id);
+   
+   jni_proc_i(FjEnv, FjObject, 'setId', FId);
   end;
 
   jni_proc_iiiiii(FjEnv, FjObject, 'SetLeftTopRightBottomWidthHeight',
@@ -391,13 +394,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
         self.AddLParamsAnchorRule(GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jsAdMob.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FjObject <> nil then
-     jni_proc_i(FjEnv, FjObject, 'SetId', _id);
 end;
 
 {-------- jsAdMob_JNI_Bridge ----------}

--- a/android_bridges/sappbarlayout.pas
+++ b/android_bridges/sappbarlayout.pas
@@ -45,7 +45,6 @@ jsAppBarLayout = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure SetFitsSystemWindows(_value: boolean);
     procedure SetBackgroundToPrimaryColor();
 
@@ -85,6 +84,9 @@ implementation
 constructor jsAppBarLayout.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+  
+  if gapp <> nil then FId := gapp.GetNewId();
+
   FMarginLeft   := 0;
   FMarginTop    := 0;
   FMarginBottom := 0;
@@ -346,13 +348,6 @@ begin
   end;
 end;
 
-procedure jsAppBarLayout.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jsAppBarLayout_SetId(FjEnv, FjObject, _id);
-end;
-
 procedure jsAppBarLayout.SetFitsSystemWindows(_value: boolean);
 begin
   //in designing component state: set value here...
@@ -607,7 +602,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jsappbarlayout);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jsappbarlayout, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/sbottomnavigationview.pas
+++ b/android_bridges/sbottomnavigationview.pas
@@ -45,8 +45,7 @@ jsBottomNavigationView = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
-
+    
     function GetMenu(): jObject;
     procedure ClearMenu();
 
@@ -116,6 +115,9 @@ implementation
 constructor jsBottomNavigationView.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 0;
   FMarginTop    := 0;
   FMarginBottom := 0;
@@ -369,13 +371,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jsBottomNavigationView_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jsBottomNavigationView.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jsBottomNavigationView_SetId(FjEnv, FjObject, _id);
 end;
 
 function jsBottomNavigationView.GetMenu(): jObject;
@@ -709,7 +704,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jsbottomnavigationview);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jsbottomnavigationview, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/scardview.pas
+++ b/android_bridges/scardview.pas
@@ -44,7 +44,6 @@ jsCardView = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure SetCardElevation(_elevation: single);
     procedure SetContentPadding(_left: integer; _top: integer; _right: integer; _bottom: integer);
     procedure SetFitsSystemWindows(_value: boolean);
@@ -88,6 +87,9 @@ implementation
 constructor jsCardView.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 4;
   FMarginTop    := 4;
   FMarginBottom := 4;
@@ -349,13 +351,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jsCardView_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jsCardView.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jsCardView_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jsCardView.SetCardElevation(_elevation: single);
@@ -626,7 +621,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jscardview);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jscardview, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/scollapsingtoolbarlayout.pas
+++ b/android_bridges/scollapsingtoolbarlayout.pas
@@ -45,7 +45,6 @@ jsCollapsingToolbarLayout = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure SetScrollFlag(_collapsingScrollFlag: TCollapsingScrollflag);
     procedure SetExpandedTitleColorTransparent();
     procedure SetExpandedTitleColor(_color: TARGBColorBridge);
@@ -97,7 +96,10 @@ implementation
 
 constructor jsCollapsingToolbarLayout.Create(AOwner: TComponent);
 begin
-  inherited Create(AOwner);                                                                              
+  inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+                                                                                
   FMarginLeft   := 0;
   FMarginTop    := 0;
   FMarginBottom := 0;
@@ -355,13 +357,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jsCollapsingToolbarLayout_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jsCollapsingToolbarLayout.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jsCollapsingToolbarLayout_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jsCollapsingToolbarLayout.SetScrollFlag(_collapsingScrollFlag: TCollapsingScrollflag);
@@ -667,7 +662,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jscollapsingtoolbarlayout);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jscollapsingtoolbarlayout, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/scontinuousscrollableimageview.pas
+++ b/android_bridges/scontinuousscrollableimageview.pas
@@ -54,8 +54,7 @@ jsContinuousScrollableImageView = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayoutAll();
-    procedure SetId(_id: integer);
-
+    
     procedure SetImageIdentifier(_imageIdentifier: string);
     procedure SetDirection(_direction: TScrollDirection);
     procedure SetDuration(_duration: integer);
@@ -105,6 +104,9 @@ implementation
 constructor jsContinuousScrollableImageView.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 10;
   FMarginTop    := 10;
   FMarginBottom := 10;
@@ -383,13 +385,6 @@ begin
      jsContinuousScrollableImageView_ClearLayoutAll(FjEnv, FjObject);
 end;
 
-procedure jsContinuousScrollableImageView.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jsContinuousScrollableImageView_SetId(FjEnv, FjObject, _id);
-end;
-
 procedure jsContinuousScrollableImageView.SetImageIdentifier(_imageIdentifier: string);
 begin
   //in designing component state: set value here...
@@ -661,7 +656,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jscontinuousscrollableimageview);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jscontinuousscrollableimageview, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/scoordinatorlayout.pas
+++ b/android_bridges/scoordinatorlayout.pas
@@ -45,7 +45,6 @@ jsCoordinatorLayout = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure SetFitsSystemWindows(_value: boolean);
 
  published
@@ -84,6 +83,9 @@ implementation
 constructor jsCoordinatorLayout.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 0;
   FMarginTop    := 0;
   FMarginBottom := 0;
@@ -350,13 +352,6 @@ begin
   end;
 end;
 
-procedure jsCoordinatorLayout.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jsCoordinatorLayout_SetId(FjEnv, FjObject, _id);
-end;
-
 procedure jsCoordinatorLayout.SetFitsSystemWindows(_value: boolean);
 begin
   //in designing component state: set value here...
@@ -614,7 +609,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jscoordinatorlayout);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jscoordinatorlayout, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/sdrawerlayout.pas
+++ b/android_bridges/sdrawerlayout.pas
@@ -45,8 +45,7 @@ jsDrawerLayout = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
-
+    
    // procedure CloseDrawer();
     procedure CloseDrawers();
     procedure OpenDrawer();
@@ -94,6 +93,9 @@ implementation
 constructor jsDrawerLayout.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 0;
   FMarginTop    := 0;
   FMarginBottom := 0;
@@ -353,13 +355,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jsDrawerLayout_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jsDrawerLayout.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jsDrawerLayout_SetId(FjEnv, FjObject, _id);
 end;
 
 {
@@ -643,7 +638,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jsdrawerlayout);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jsdrawerlayout, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/searchview.pas
+++ b/android_bridges/searchview.pas
@@ -55,7 +55,6 @@ jSearchView = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     function GetQuery(): string;
     function GetQueryHint(): string;
     function IsIconfiedByDefault(): boolean;
@@ -123,6 +122,9 @@ implementation
 constructor jSearchView.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 10;
   FMarginTop    := 10;
   FMarginBottom := 10;
@@ -372,13 +374,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jSearchView_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jSearchView.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jSearchView_SetId(FjEnv, FjObject, _id);
 end;
 
 function jSearchView.GetQuery(): string;
@@ -709,7 +704,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jsearchview);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jsearchview, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/sedittextfloatinglabel.pas
+++ b/android_bridges/sedittextfloatinglabel.pas
@@ -44,8 +44,7 @@ jsEditTextFloatingLabel = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
-
+    
  published
     property BackgroundColor: TARGBColorBridge read FColor write SetColor;
     property OnClick: TOnNotify read FOnClick write FOnClick;
@@ -79,6 +78,9 @@ implementation
 constructor jsEditTextFloatingLabel.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+
   FMarginLeft   := 10;
   FMarginTop    := 10;
   FMarginBottom := 10;
@@ -324,13 +326,6 @@ begin
   end;
 end;
 
-procedure jsEditTextFloatingLabel.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jsEditTextFloatingLabel_SetId(FjEnv, FjObject, _id);
-end;
-
 {-------- jsEditTextFloatingLabel_JNI_Bridge ----------}
 
 function jsEditTextFloatingLabel_jCreate(env: PJNIEnv;_Self: int64; this: jObject): jObject;
@@ -570,7 +565,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jsedittextfloatinglabel);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jsedittextfloatinglabel, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/seekbar.pas
+++ b/android_bridges/seekbar.pas
@@ -50,7 +50,6 @@ jSeekBar = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure SetMax(_maxProgress: integer);
     procedure SetProgress(_progress: integer);
     function GetProgress(): integer;
@@ -103,6 +102,9 @@ implementation
 constructor jSeekBar.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 10;
   FMarginTop    := 10;
   FMarginBottom := 10;
@@ -323,13 +325,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jSeekBar_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jSeekBar.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jSeekBar_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jSeekBar.SetMax(_maxProgress: integer);
@@ -571,7 +566,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jseekbar);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jseekbar, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/sfloatingbutton.pas
+++ b/android_bridges/sfloatingbutton.pas
@@ -47,7 +47,6 @@ jsFloatingButton = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure SetVisibility(_value: TViewVisibility);
     procedure SetCompatElevation(_value: single);
     procedure SetImageIdentifier(_imageIdentifier: string);
@@ -107,6 +106,9 @@ implementation
 constructor jsFloatingButton.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 10;
   FMarginTop    := 10;
   FMarginBottom := 10;
@@ -353,13 +355,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jsFloatingButton_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jsFloatingButton.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jsFloatingButton_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jsFloatingButton.SetVisibility(_value: TViewVisibility);
@@ -683,7 +678,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jsfloatingbutton);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jsfloatingbutton, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/snavigationview.pas
+++ b/android_bridges/snavigationview.pas
@@ -44,7 +44,6 @@ jsNavigationView = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure SetItemBackground(_imageIdentifier: string);
     procedure SetItemBackgroundResource(_imageIdentifier: string);
     function GetMenu(): jObject;
@@ -121,6 +120,9 @@ implementation
 constructor jsNavigationView.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 0;
   FMarginTop    := 0;
   FMarginBottom := 0;
@@ -368,13 +370,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jsNavigationView_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jsNavigationView.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jsNavigationView_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jsNavigationView.SetItemBackground(_imageIdentifier: string);
@@ -755,7 +750,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jsnavigationview);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jsnavigationview, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/snestedscrollview.pas
+++ b/android_bridges/snestedscrollview.pas
@@ -45,7 +45,6 @@ jsNestedScrollView = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure SetAppBarLayoutScrollingViewBehavior();
     procedure SetFitsSystemWindows(_value: boolean);
     procedure SetNestedScrollingEnabled(_view: jObject);
@@ -86,6 +85,9 @@ implementation
 constructor jsNestedScrollView.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 0;
   FMarginTop    := 0;
   FMarginBottom := 0;
@@ -345,13 +347,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jsNestedScrollView_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jsNestedScrollView.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jsNestedScrollView_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jsNestedScrollView.SetAppBarLayoutScrollingViewBehavior();
@@ -615,7 +610,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jsnestedscrollview);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jsnestedscrollview, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/spinner.pas
+++ b/android_bridges/spinner.pas
@@ -62,7 +62,6 @@ TOnItemSelected = procedure(Sender: TObject; itemCaption: string; itemIndex: int
     procedure AddLParamsAnchorRule(_rule: integer);
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
-    procedure SetId(_id: integer);
     function GetSelectedItemPosition(): integer;
     function GetSelectedItem(): string;
     procedure Add(_item: string); overload;
@@ -172,6 +171,9 @@ implementation
 constructor jSpinner.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 5;
   FMarginTop    := 5;
   FMarginBottom := 5;
@@ -434,13 +436,6 @@ begin
   //in designing component state: set value here...
   if FInitialized then
      jSpinner_SetLayoutAll(FjEnv, FjObject , _idAnchor);
-end;
-
-procedure jSpinner.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jSpinner_SetId(FjEnv, FjObject , _id);
 end;
 
 function jSpinner.GetSelectedItemPosition(): integer;
@@ -869,7 +864,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jspinner);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jspinner, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/srecyclerview.pas
+++ b/android_bridges/srecyclerview.pas
@@ -75,7 +75,6 @@ jsRecyclerView = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure SetItemContentFormat(_delimitedContentFormat: string; _delimiter: string); overload;
     procedure SetItemContentFormat(_contentFormat: string); overload;
     procedure SetItemContentFormat(); overload;
@@ -145,6 +144,9 @@ implementation
 constructor jsRecyclerView.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 10;
   FMarginTop    := 10;
   FMarginBottom := 10;
@@ -418,13 +420,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jsRecyclerView_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jsRecyclerView.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jsRecyclerView_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jsRecyclerView.SetItemContentFormat(_delimitedContentFormat: string; _delimiter: string);
@@ -771,7 +766,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jsrecyclerview);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jsrecyclerview, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/stablayout.pas
+++ b/android_bridges/stablayout.pas
@@ -54,7 +54,6 @@ jsTabLayout = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure SetupWithViewPager(_viewPage: jObject);
     procedure SetFitsSystemWindows(_value: boolean);
     function AddTab(_title: string): integer;
@@ -131,6 +130,9 @@ implementation
 constructor jsTabLayout.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 0;
   FMarginTop    := 0;
   FMarginBottom := 0;
@@ -386,13 +388,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jsTabLayout_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jsTabLayout.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jsTabLayout_SetId(FjEnv, FjObject, _id);
 end;
 
 function jsTabLayout.AddTab(_title: string): integer;
@@ -768,7 +763,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jstablayout);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jstablayout, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/stextinput.pas
+++ b/android_bridges/stextinput.pas
@@ -52,7 +52,6 @@ jsTextInput = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure SetHint(_hint: string);
     procedure SetHintTextColor(_color: TARGBColorBridge);
     procedure CopyToClipboard();
@@ -103,6 +102,9 @@ implementation
 constructor jsTextInput.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 10;
   FMarginTop    := 10;
   FMarginBottom := 10;
@@ -369,13 +371,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jsTextInput_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jsTextInput.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jsTextInput_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jsTextInput.SetFontColor(_color: TARGBColorBridge);
@@ -675,7 +670,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jstextinput);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jstextinput, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/stoolbar.pas
+++ b/android_bridges/stoolbar.pas
@@ -50,7 +50,6 @@ jsToolbar = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure SetTitle(_title: string);
     procedure SetNavigationIcon(_imageIdentifier: string);
     procedure SetLogoIcon(_imageIdentifier: string);
@@ -138,6 +137,9 @@ implementation
 constructor jsToolbar.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 0;
   FMarginTop    := 0;
   FMarginBottom := 0;
@@ -410,13 +412,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jsToolbar_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jsToolbar.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jsToolbar_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jsToolbar.SetTitle(_title: string);
@@ -818,7 +813,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jstoolbar);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jstoolbar, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/surfaceview.pas
+++ b/android_bridges/surfaceview.pas
@@ -58,8 +58,7 @@ jSurfaceView = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
-
+    
     procedure SetHolderFixedSize(_width: integer; _height: integer);
     procedure DrawLine(_canvas: jObject; _x1: single; _y1: single; _x2: single; _y2: single);  overload;
     procedure DrawPoint(_canvas: jObject; _x1: single; _y1: single);
@@ -175,6 +174,9 @@ implementation
 constructor jSurfaceView.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 10;
   FMarginTop    := 10;
   FMarginBottom := 10;
@@ -395,13 +397,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jSurfaceView_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jSurfaceView.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jSurfaceView_SetId(FjEnv, FjObject, _id);
 end;
 
 
@@ -816,7 +811,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jsurfaceview);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jsurfaceview, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/sviewpager.pas
+++ b/android_bridges/sviewpager.pas
@@ -48,7 +48,6 @@ jsViewPager = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure AddPage(_view: jObject; _title: string);
     function GetPageTitle(_position: integer): string;
     function GetPosition(): integer;
@@ -103,6 +102,9 @@ implementation
 constructor jsViewPager.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 0;
   FMarginTop    := 0;
   FMarginBottom := 0;
@@ -358,13 +360,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jsViewPager_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jsViewPager.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jsViewPager_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jsViewPager.AddPage(_view: jObject; _title: string);
@@ -670,7 +665,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jsviewpager);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jsviewpager, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/switchbutton.pas
+++ b/android_bridges/switchbutton.pas
@@ -46,7 +46,6 @@ type
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure SetTextOff(_caption: string);
     procedure SetTextOn(_caption: string);
     procedure SetChecked(_state: boolean);
@@ -98,6 +97,9 @@ implementation
 constructor jSwitchButton.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 7;
   FMarginTop    := 7;
   FMarginBottom := 7;
@@ -327,13 +329,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jSwitchButton_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jSwitchButton.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jSwitchButton_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jSwitchButton.SetTextOff(_caption: string);
@@ -605,7 +600,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jswitchbutton);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jswitchbutton, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/togglebutton.pas
+++ b/android_bridges/togglebutton.pas
@@ -41,7 +41,6 @@ type
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure SetChecked(_value: boolean);
     procedure DispatchOnToggleEvent(_value: boolean);
     procedure SetTextOn(_caption: string);
@@ -91,6 +90,9 @@ implementation
 constructor jToggleButton.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 10;
   FMarginTop    := 10;
   FMarginBottom := 10;
@@ -319,13 +321,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jToggleButton_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jToggleButton.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jToggleButton_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jToggleButton.SetChecked(_value: boolean);
@@ -588,7 +583,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jtogglebutton);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jtogglebutton, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/toolbar.pas
+++ b/android_bridges/toolbar.pas
@@ -51,8 +51,7 @@ jToolbar = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
-
+    
     procedure SetTitle(_title: string);
     procedure SetNavigationIcon(_imageIdentifier: string);
     procedure SetLogoIcon(_imageIdentifier: string);
@@ -108,6 +107,9 @@ implementation
 constructor jToolbar.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 0;
   FMarginTop    := 0;
   FMarginBottom := 0;
@@ -385,13 +387,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jToolbar_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jToolbar.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jToolbar_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jToolbar.SetTitle(_title: string);
@@ -694,7 +689,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jtoolbar);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jtoolbar, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/treelistview.pas
+++ b/android_bridges/treelistview.pas
@@ -62,8 +62,7 @@ type
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
-
+    
     function AddChild(AParent: integer): integer;
     procedure Clear;
     function GetFirstChild(parent_id: integer): integer;
@@ -135,6 +134,9 @@ end;
 constructor jTreeListView.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 10;
   FMarginTop    := 10;
   FMarginBottom := 10;
@@ -390,13 +392,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jTreeListView_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jTreeListView.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jTreeListView_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jTreeListView.SetLevels(count: integer);
@@ -716,7 +711,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jtreelistview);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jtreelistview, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/videoview.pas
+++ b/android_bridges/videoview.pas
@@ -44,7 +44,6 @@ jVideoView = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure Pause();
     procedure Resume();
     procedure SeekTo(_position: integer);
@@ -95,6 +94,9 @@ implementation
 constructor jVideoView.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 10;
   FMarginTop    := 10;
   FMarginBottom := 10;
@@ -341,13 +343,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jVideoView_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jVideoView.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jVideoView_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jVideoView.Pause();
@@ -638,7 +633,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jvideoview);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jvideoview, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/viewflipper.pas
+++ b/android_bridges/viewflipper.pas
@@ -47,7 +47,6 @@ jViewFlipper = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    procedure SetId(_id: integer);
     procedure SetAutoStart(_value: boolean);
     procedure SetFlipInterval(_milliseconds: integer);
     procedure StartFlipping();
@@ -102,6 +101,9 @@ implementation
 constructor jViewFlipper.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 10;
   FMarginTop    := 10;
   FMarginBottom := 10;
@@ -356,13 +358,6 @@ begin
        if rToA in FPositionRelativeToAnchor then
          jViewFlipper_addlParamsAnchorRule(FjEnv, FjObject , GetPositionRelativeToAnchor(rToA));
   end;
-end;
-
-procedure jViewFlipper.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jViewFlipper_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jViewFlipper.SetAutoStart(_value: boolean);
@@ -689,7 +684,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jviewflipper);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jviewflipper, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/zbarcodescannerview.pas
+++ b/android_bridges/zbarcodescannerview.pas
@@ -67,7 +67,6 @@ jZBarcodeScannerView = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayoutAll();
-    procedure SetId(_id: integer);
     procedure Scan(); overload;
     procedure Scan(_barcodeBmp: jObject); overload;
 
@@ -109,6 +108,9 @@ implementation
 constructor jZBarcodeScannerView.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
+
+  if gapp <> nil then FId := gapp.GetNewId();
+  
   FMarginLeft   := 10;
   FMarginTop    := 10;
   FMarginBottom := 10;
@@ -364,13 +366,6 @@ begin
   //in designing component state: set value here...
   if FInitialized then
      jZBarcodeScannerView_ClearLayoutAll(FjEnv, FjObject);
-end;
-
-procedure jZBarcodeScannerView.SetId(_id: integer);
-begin
-  //in designing component state: set value here...
-  if FInitialized then
-     jZBarcodeScannerView_SetId(FjEnv, FjObject, _id);
 end;
 
 procedure jZBarcodeScannerView.Scan();
@@ -632,7 +627,7 @@ var
 begin
   jParams[0].i:= _id;
   jCls:= env^.GetObjectClass(env, _jbarcodescannerview);
-  jMethod:= env^.GetMethodID(env, jCls, 'SetId', '(I)V');
+  jMethod:= env^.GetMethodID(env, jCls, 'setId', '(I)V');
   env^.CallVoidMethodA(env, _jbarcodescannerview, jMethod, @jParams);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_wizard/lamwdesigner.pas
+++ b/android_wizard/lamwdesigner.pas
@@ -1859,9 +1859,9 @@ end;
 
 procedure TAndroidWidgetMediator.OnAutoAssignIDs(Sender: TObject);
 begin
-  if (Sender is TAndroidForm) and TAndroidForm(Sender).AutoAssignIDs then
+  (*if (Sender is TAndroidForm) and TAndroidForm(Sender).AutoAssignIDs then
     if QuestionDlg('LAMW', 'Reassign Id properties now (otherwise they will be reassigned on next form open)?', mtConfirmation, [mrYes, mrNo], 0) = mrYes then
-      TAndroidForm(Sender).ReassignIds;
+      TAndroidForm(Sender).ReassignIds;*)
 end;
 
 procedure TAndroidWidgetMediator.SetRoot(const AValue: TComponent);

--- a/android_wizard/smartdesigner/java/Controls.java
+++ b/android_wizard/smartdesigner/java/Controls.java
@@ -1699,6 +1699,8 @@ public RelativeLayout  appLayout; // Base Layout
 public int screenStyle=0;         // Screen Style [Dev:0 , Portrait: 1, Landscape : 2]
 public int systemVersion;
 
+private int javaNewId = 100000;   // To assign java id to 100000 ... native 0..100000
+
 //Jave -> Pascal Function ( Pascal Side = Event )
 public native void pAppOnCreate(Context context, RelativeLayout layout, Intent intent);
 public native int  pAppOnScreenStyle();
@@ -1793,6 +1795,13 @@ public boolean jAppOnKeyDown(char keyChar , int keyCode, String keyCodeString) {
 
 public  void jAppOnRequestPermissionResult(int requestCode, String permission, int grantResult) {
 	pAppOnRequestPermissionResult(requestCode, permission ,grantResult);
+}
+
+// For internal id of componente 100000 or higher
+
+public int getJavaNewId(){
+	javaNewId = javaNewId + 1;
+	return javaNewId;
 }
 
 //// -------------------------------------------------------------------------

--- a/android_wizard/smartdesigner/java/Controls.native
+++ b/android_wizard/smartdesigner/java/Controls.native
@@ -1,3 +1,4 @@
+private int javaNewId = 100000;   // To assign java id to 100000 ... native 0..100000
 public native void pAppOnCreate(Context context, RelativeLayout layout, Intent intent);
 public native int  pAppOnScreenStyle();
 public native void pAppOnNewIntent(Intent intent);

--- a/android_wizard/smartdesigner/java/OpenGLSurfaceView.java
+++ b/android_wizard/smartdesigner/java/OpenGLSurfaceView.java
@@ -229,10 +229,6 @@ public class OpenGLSurfaceView extends SurfaceView implements SurfaceHolder.Call
            countAnchorRule = 0;
            countParentRule = 0;
      }
-      
-     public void SetId(int _id) { //wrapper method pattern ...
-           this.setId(_id);
-     }
        
     //write others [public] methods code here......
     //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...

--- a/android_wizard/smartdesigner/java/jAnalogClock.java
+++ b/android_wizard/smartdesigner/java/jAnalogClock.java
@@ -94,10 +94,6 @@ public class jAnalogClock extends AnalogClock /*dummy*/ { //please, fix what GUI
 	   LAMWCommon.clearLayoutAll();
    }
 
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
-
    //write others [public] methods code here......
    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
 

--- a/android_wizard/smartdesigner/java/jAutoTextView.java
+++ b/android_wizard/smartdesigner/java/jAutoTextView.java
@@ -190,10 +190,6 @@ public class jAutoTextView extends AutoCompleteTextView /*dummy*/ { //please, fi
       return this;
    }
    
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
-
    //write others [public] methods code here......
    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
 

--- a/android_wizard/smartdesigner/java/jCalendarView.java
+++ b/android_wizard/smartdesigner/java/jCalendarView.java
@@ -115,10 +115,7 @@ public class jCalendarView extends CalendarView /*dummy*/ { //please, fix what G
     }
 
     //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-    public void SetId(int _id) { //wrapper method pattern ...
-        this.setId(_id);
-    }
-
+    
     private String getDateString(long currentDateTime){
         //creating Date from millisecond
         Date currentDate = new Date(currentDateTime);  //Examples of patterns are dd/MM/yyyy, dd-MM-yyyy, MM/dd/yyyy, yyyy-MM-dd.

--- a/android_wizard/smartdesigner/java/jCheckBox.java
+++ b/android_wizard/smartdesigner/java/jCheckBox.java
@@ -89,10 +89,6 @@ public class jCheckBox extends CheckBox {
 	public void ClearLayoutAll() {		//TODO Pascal
 		LAMWCommon.clearLayoutAll();
 	}
-	
-	public void setIdEx(int id) {
-		setId(id);
-	}
 
 	public void setTextColor2(int value) {
 		this.setTextColor(value);

--- a/android_wizard/smartdesigner/java/jChronometer.java
+++ b/android_wizard/smartdesigner/java/jChronometer.java
@@ -108,10 +108,6 @@ class jChronometer extends Chronometer /*dummy*/ { //please, fix what GUI object
     	LAMWCommon.clearLayoutAll();
     }
 
-    public void SetId(int _id) { //wrapper method pattern ...
-        this.setId(_id);
-    }
-
     //write others [public] methods code here......
 
     //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...

--- a/android_wizard/smartdesigner/java/jComboEditText.java
+++ b/android_wizard/smartdesigner/java/jComboEditText.java
@@ -435,10 +435,6 @@ public class jComboEditText extends AutoCompleteTextView /*dummy*/ { //please, f
    public View GetView() {
       return this;
    }
-   
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
 
    //write others [public] methods code here......
    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...

--- a/android_wizard/smartdesigner/java/jCustomCamera.java
+++ b/android_wizard/smartdesigner/java/jCustomCamera.java
@@ -377,10 +377,7 @@ public class jCustomCamera  extends SurfaceView implements SurfaceHolder.Callbac
     }
 
     //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-    public void SetId(int _id) { //wrapper method pattern ...
-        this.setId(_id);
-    }
-
+    
     private Bitmap decodeSampleImage(File f, int width, int height) {
         try {
             System.gc(); // First of all free some memory //Decode image size

--- a/android_wizard/smartdesigner/java/jCustomDialog.java
+++ b/android_wizard/smartdesigner/java/jCustomDialog.java
@@ -207,10 +207,6 @@ public class jCustomDialog extends RelativeLayout {
 		countParentRule = 0;
 	}
 
-	public void SetId(int _id) { //wrapper method pattern ...
-		this.setId(_id);
-	}
-
 	//write others [public] methods code here......
 	//GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
 	private int GetDrawableResourceId(String _resName) {   //    ../res/drawable

--- a/android_wizard/smartdesigner/java/jDBListView.java
+++ b/android_wizard/smartdesigner/java/jDBListView.java
@@ -79,10 +79,11 @@ class jDBRecordView extends ListView {
 	
     private jDBCursorAdapter mCustomAdapter;
 	
-	public jDBRecordView(Context context, long _Self) { //Add more others news "_xxx" params if needed!
-        super(context);
+	public jDBRecordView(Controls _ctrls, long _Self) { //Add more others news "_xxx" params if needed!
+        super(_ctrls.activity);
 		
-        mContext  = context;
+        controls  = _ctrls;
+        mContext  = _ctrls.activity;
         pascalObj = _Self;
         LAMWCommon = new jCommons(this, mContext, pascalObj);
         LAMWCommon.setMarginLeftTopRightBottom(0, 0, 0, 0);
@@ -91,7 +92,7 @@ class jDBRecordView extends ListView {
 		ColorDrawable dvdr = new ColorDrawable(0xFF000000);
 		setDivider(dvdr);
 		setDividerHeight(1);
-		setId(0xBABE);
+		setId(controls.getJavaNewId());
 		
 		mColumnWeight = new float[]{1f};
 
@@ -160,10 +161,6 @@ class jDBRecordView extends ListView {
 
     public void ClearLayoutAll() {   //TODO Pascal
 		LAMWCommon.clearLayoutAll();
-    }
-
-    public void SetId(int _id) { //wrapper method pattern ...
-        this.setId(_id);
     }
 
     public void SetFontSize(int _size) {
@@ -295,7 +292,7 @@ class jDBRecordView extends ListView {
 		// Log.i("jDBRecordView", "newHeader ...");
 		final int len = mColumnNames.length;
 		LinearLayout header = new LinearLayout(mContext);
-		header.setId(0x0D01);
+		header.setId(controls.getJavaNewId());
 		header.setOrientation(LinearLayout.HORIZONTAL);
 		header.setGravity(Gravity.CENTER);
 		header.setShowDividers(LinearLayout.SHOW_DIVIDER_MIDDLE);
@@ -392,12 +389,13 @@ public class jDBListView extends LinearLayout {
         super(_ctrls.activity);
 		
         controls  = _ctrls;
-        context   = controls.activity;
+        context   = _ctrls.activity;
         pascalObj = _Self;
         LAMWCommon = new jCommons(this, context, pascalObj);
         
 		setOrientation(LinearLayout.VERTICAL);
-		mItemList = new jDBRecordView(context, pascalObj);
+		mItemList = new jDBRecordView(controls, pascalObj);
+		mItemList.setId(controls.getJavaNewId());
 		mItemList.SetViewParent(this);
 		mItemList.SetLParamWidth(android.view.ViewGroup.LayoutParams.MATCH_PARENT);
 		
@@ -485,10 +483,6 @@ public class jDBListView extends LinearLayout {
 
     public void ClearLayoutAll() {   //TODO Pascal
 		LAMWCommon.clearLayoutAll();
-    }
-
-    public void SetId(int _id) { //wrapper method pattern ...
-        this.setId(_id);
     }
 
     public View GetView() {

--- a/android_wizard/smartdesigner/java/jDigitalClock.java
+++ b/android_wizard/smartdesigner/java/jDigitalClock.java
@@ -98,10 +98,6 @@ public class jDigitalClock extends DigitalClock /*TextClock*/ { //please, fix wh
 		LAMWCommon.clearLayoutAll();
 	}
 
-	public void SetId(int _id) { //wrapper method pattern ...
-		this.setId(_id);
-	}
-
 	//write others [public] methods code here......
 	//GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
 

--- a/android_wizard/smartdesigner/java/jDrawingView.java
+++ b/android_wizard/smartdesigner/java/jDrawingView.java
@@ -201,10 +201,6 @@ public class jDrawingView extends View /*dummy*/ { //please, fix what GUI object
         return this;
     }
 
-    public void SetId(int _id) { //wrapper method pattern ...
-        this.setId(_id);
-    }
-
     //write others [public] methods code here......
     //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
 

--- a/android_wizard/smartdesigner/java/jExpandableListView.java
+++ b/android_wizard/smartdesigner/java/jExpandableListView.java
@@ -56,7 +56,8 @@ class ChildInfo {
 //http://techlovejump.com/android-expandable-listview-tutorial/
 
 class ExpandableListAdapter extends BaseExpandableListAdapter {
-	 
+	
+	private Controls controls  = null;
     private Context _context;
     
     private List<HeaderInfo> _listDataHeader; // header titles
@@ -64,9 +65,11 @@ class ExpandableListAdapter extends BaseExpandableListAdapter {
     // child data in format of header info, child info
     private HashMap<HeaderInfo, List<ChildInfo>> _listDataChild;
  
-    public ExpandableListAdapter(Context context, List<HeaderInfo> listDataHeader,
+    public ExpandableListAdapter(Controls _ctrls, List<HeaderInfo> listDataHeader,
             HashMap<HeaderInfo, List<ChildInfo>> listChildData) {
-        this._context = context;
+    	
+    	controls = _ctrls;
+        this._context = _ctrls.activity;
         this._listDataHeader = listDataHeader;
         this._listDataChild = listChildData;
     }
@@ -119,14 +122,14 @@ class ExpandableListAdapter extends BaseExpandableListAdapter {
 		TextView textView = new TextView(_context); 
 		
 		textView.setText(childText);
-		textView.setId(groupPosition+childPosition+46742);
+		textView.setId(controls.getJavaNewId());
 	
 		ImageView itemImage = null;
 		RelativeLayout.LayoutParams imgParam = null; 
 		if (iconResId != 0) {
 		  imgParam = new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT); //w,h		  
 		  itemImage = new ImageView(_context);
-		  itemImage.setId(groupPosition+childPosition+16742);
+		  itemImage.setId(controls.getJavaNewId());
 		  itemImage.setImageResource(iconResId);
 		  itemImage.setFocusable(false);
 		  itemImage.setFocusableInTouchMode(false);		
@@ -286,14 +289,14 @@ class ExpandableListAdapter extends BaseExpandableListAdapter {
 		LayoutParams txtParam = new LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT); //w,h  //layText							
 		TextView textView = new TextView(_context); 		
 		textView.setText(headerTitle);
-		textView.setId(groupPosition+36742);		
+		textView.setId(controls.getJavaNewId());
 		
 		ImageView itemImage = null;
 		RelativeLayout.LayoutParams imgParam = null;
 		if (iconResId != 0) {
 		  imgParam = new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT); //w,h		
 		  itemImage = new ImageView(_context);
-		  itemImage.setId(groupPosition+26742);		  
+		  itemImage.setId(controls.getJavaNewId());
 		  itemImage.setImageResource(iconResId);
 		  itemImage.setFocusable(false);
 		  itemImage.setFocusableInTouchMode(false);
@@ -455,7 +458,7 @@ public class jExpandableListView extends ExpandableListView /*dummy*/ { //please
       // preparing list data
       listDataHeader = new ArrayList<HeaderInfo>();
       listDataChild = new HashMap<HeaderInfo, List<ChildInfo>>();
-      listAdapter = new ExpandableListAdapter(controls.activity, listDataHeader, listDataChild);
+      listAdapter = new ExpandableListAdapter(controls, listDataHeader, listDataChild);
       
       // setting list adapter      
       this.setAdapter(listAdapter);
@@ -592,9 +595,6 @@ public class jExpandableListView extends ExpandableListView /*dummy*/ { //please
    }
 
    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
 
    public void SetItemHeaderDelimiter(String _itemHeaderDelimiter) {
 	   headerDelimiter = _itemHeaderDelimiter;

--- a/android_wizard/smartdesigner/java/jFrameLayout.java
+++ b/android_wizard/smartdesigner/java/jFrameLayout.java
@@ -106,9 +106,4 @@ public class jFrameLayout extends FrameLayout /*dummy*/ { //please, fix what GUI
 	 LAMWCommon.clearLayoutAll();
    }
 
-   //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
-
 }

--- a/android_wizard/smartdesigner/java/jGL2SurfaceView.java
+++ b/android_wizard/smartdesigner/java/jGL2SurfaceView.java
@@ -546,13 +546,7 @@ private long pascalObj = 0;        // Pascal Object
 
    public void ClearLayoutAll() {
 	 LAMWCommon.clearLayoutAll();
-   }
-
-   //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
-    
+   }    
 
     @Override
 	public void surfaceDestroyed(SurfaceHolder holder) {

--- a/android_wizard/smartdesigner/java/jGridView.java
+++ b/android_wizard/smartdesigner/java/jGridView.java
@@ -328,10 +328,6 @@ public class jGridView extends GridView /*dummy*/ { //please, fix what GUI objec
 		LAMWCommon.clearLayoutAll();
     }
 
-    public void SetId(int _id) { //wrapper method pattern ...
-        this.setId(_id);
-    }
-
     //write others [public] methods code here......
     //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
 

--- a/android_wizard/smartdesigner/java/jLinearLayout.java
+++ b/android_wizard/smartdesigner/java/jLinearLayout.java
@@ -110,9 +110,6 @@ public class jLinearLayout extends LinearLayout /*dummy*/ { //please, fix what G
    }
 
    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
       
    public void SetOrientation(int _orientation) {
 	   switch(_orientation) {

--- a/android_wizard/smartdesigner/java/jListView.java
+++ b/android_wizard/smartdesigner/java/jListView.java
@@ -532,7 +532,7 @@ class jArrayAdapter extends ArrayAdapter {
 				     
 				     if ( txt1.length() > 0) {
 				       itemTextLeft = new TextView(ctx);  
-				       itemTextLeft.setId(position + 1111);
+				       itemTextLeft.setId(controls.getJavaNewId());
 				       //itemTextLeft.setPadding(20, 40, 20, 40);
 				       itemTextLeft.setPadding(mItemPaddingLeft, mItemPaddingTop, 0, mItemPaddingBottom);
 				       
@@ -580,7 +580,7 @@ class jArrayAdapter extends ArrayAdapter {
 				   
 				   if (txt2.length() > 0) { 
 				     itemTextRight = new TextView(ctx);
-				     itemTextRight.setId(position + 2222);
+				     itemTextRight.setId(controls.getJavaNewId());
 				     //itemTextRight.setPadding(20, 40, 20, 40);
 				     itemTextRight.setPadding(0, mItemPaddingTop, mItemPaddingRight, mItemPaddingBottom);
 				     itemTextRight.setText(txt2);
@@ -623,7 +623,7 @@ class jArrayAdapter extends ArrayAdapter {
 			
 			if (imageBmp != null) {
 				itemImage = new ImageView(ctx);
-				itemImage.setId(position+4444);
+				itemImage.setId(controls.getJavaNewId());
 				itemImage.setPadding(paddingLeft, paddingTop, paddingRight, paddingBottom);
 				itemImage.setImageBitmap(imageBmp);
 				itemImage.setFocusable(false);
@@ -635,7 +635,7 @@ class jArrayAdapter extends ArrayAdapter {
 			
 	    if (items.get(position).bmp !=  null) {
 					itemImage = new ImageView(ctx);
-					itemImage.setId(position+4444);
+					itemImage.setId(controls.getJavaNewId());
 					itemImage.setPadding(paddingLeft, paddingTop, paddingRight, paddingBottom);
 					itemImage.setImageBitmap(items.get(position).bmp);
 					itemImage.setFocusable(false);
@@ -771,7 +771,7 @@ class jArrayAdapter extends ArrayAdapter {
 
 			switch(items.get(position).widget) {   //0 == there is not a widget!
 				case 1:  itemWidget = new CheckBox(ctx);
-					((CheckBox)itemWidget).setId(position+6666); //dummy
+					((CheckBox)itemWidget).setId(controls.getJavaNewId());
 
 					((CheckBox)itemWidget).setTextColor(controls.activity.getResources().getColor(R.color.primary_text));
 					
@@ -811,7 +811,7 @@ class jArrayAdapter extends ArrayAdapter {
 					break;
 					
 				case 2:  itemWidget = new RadioButton(ctx);
-					((RadioButton)itemWidget).setId(position+6666);
+					((RadioButton)itemWidget).setId(controls.getJavaNewId());
 					((RadioButton)itemWidget).setTextColor(controls.activity.getResources().getColor(R.color.primary_text));
 					
 					((RadioButton)itemWidget).setPadding(0, mItemPaddingTop, 0, mItemPaddingBottom);
@@ -850,7 +850,7 @@ class jArrayAdapter extends ArrayAdapter {
 					break;
 					
 				case 3:  itemWidget = new Button(ctx);
-					((Button)itemWidget).setId(position+6666);
+					((Button)itemWidget).setId(controls.getJavaNewId());
 					((Button)itemWidget).setTextColor(controls.activity.getResources().getColor(R.color.primary_text));
 					
 					((Button)itemWidget).setPadding(0, mItemPaddingTop, 0, mItemPaddingBottom);
@@ -887,7 +887,7 @@ class jArrayAdapter extends ArrayAdapter {
 					break;
 					
 				case 4:  itemWidget = new TextView(ctx);
-					((TextView)itemWidget).setId(position+6666);
+					((TextView)itemWidget).setId(controls.getJavaNewId());
 					((TextView)itemWidget).setTextColor(controls.activity.getResources().getColor(R.color.primary_text));
 					
 					((TextView)itemWidget).setPadding(0, mItemPaddingTop, 0, mItemPaddingBottom);
@@ -924,7 +924,7 @@ class jArrayAdapter extends ArrayAdapter {
 					break;
 
 				case 5:  itemWidget = new EditText(ctx);
-					((EditText)itemWidget).setId(position+6666);
+					((EditText)itemWidget).setId(controls.getJavaNewId());
 					((EditText)itemWidget).setTextColor(controls.activity.getResources().getColor(R.color.primary_text));
 
 					if (items.get(position).widgetTextColor != 0) {
@@ -970,15 +970,23 @@ class jArrayAdapter extends ArrayAdapter {
 
 					((EditText)itemWidget).setOnFocusChangeListener(new OnFocusChangeListener() {
 						public void onFocusChange(View v, boolean hasFocus) {
-							int temp = v.getId();
-							final int index = temp - 6666; //dummy
+							int tempId = v.getId();
+							int index = -1; // = temp - 6666; //dummy
 							final EditText caption = (EditText)v;
+							
 							if (!hasFocus){
-								if (index >= 0) {
-									items.get(index).widgetText = caption.getText().toString();
+								
+								for( int i = 0; i < items.size(); i++)
+								 if( items.get(i).jWidget.getId() == tempId ){
+									 index = i;
+									 break;
+								 }
+																								
+								if (index >= 0){
+									items.get(index).widgetText = caption.getText().toString();								
 									items.get(index).jWidget.setFocusable(false);
 									items.get(index).jWidget.setFocusableInTouchMode(false);
-									controls.pOnWidgeItemLostFocus(PasObj, index, caption.getText().toString());
+								    controls.pOnWidgeItemLostFocus(PasObj, index, caption.getText().toString());
 								}
 							}
 						}

--- a/android_wizard/smartdesigner/java/jModalDialog.java
+++ b/android_wizard/smartdesigner/java/jModalDialog.java
@@ -143,7 +143,7 @@ public class jModalDialog extends Activity {
     	
         TextView title = new TextView(this);
         int id1111 = 1111;
-        title.setId(id1111);
+        title.setId(id1111); // Being a new activity you don't need "getJavaNewId ()"
         title.setPadding(20, 40, 20, 40);
         title.setText(mMessage);
         
@@ -167,7 +167,7 @@ public class jModalDialog extends Activity {
             if (mRequestInfoCount > 0) {
      		   
      	     mEditInput[0] = new EditText(this);
-     	     mEditInput[0].setId(id2222);
+     	     mEditInput[0].setId(id2222); // Being a new activity you don't need "getJavaNewId ()"
      	     mEditInput[0].setPadding(20, 30, 20, 30);
      	     mEditInput[0].setHint(mRequestHint[0]);
 
@@ -185,7 +185,7 @@ public class jModalDialog extends Activity {
            for (int j = 1;  j < mRequestInfoCount; j++) { //others inputs...
         	           	  
         	  mEditInput[j] = new EditText(this);        	  
-        	  mEditInput[j].setId(id2222+j);
+        	  mEditInput[j].setId(id2222+j); // Being a new activity you don't need "getJavaNewId ()"
         	  mEditInput[j].setPadding(20, 30, 20, 30);      
         	  //mEditInput[j].setText(mRequestInfo[j]);
         	  mEditInput[j].setHint(mRequestHint[j]);// +" "+ mRequestInfo[j].toLowerCase());
@@ -217,7 +217,7 @@ public class jModalDialog extends Activity {
         Button buttonOk = new Button(this);
 
         int id3333 = 3333;
-        buttonOk.setId(id3333);
+        buttonOk.setId(id3333); // Being a new activity you don't need "getJavaNewId ()"
         buttonOk.setPadding(20, 40, 20, 40);
         buttonOk.setText(mBtnOK);
 
@@ -283,7 +283,7 @@ public class jModalDialog extends Activity {
         if ( (mDlgType == 0)  || ((mDlgType == 2)) ){  //  == dlgInputBox,  dlgShowQuestion
         	
           Button buttonCancel = new Button(this);
-          buttonCancel.setId(id3334);
+          buttonCancel.setId(id3334); // Being a new activity you don't need "getJavaNewId ()"
           buttonCancel.setPadding(20, 40, 20, 40);
           buttonCancel.setText(mBtnCancel);
         

--- a/android_wizard/smartdesigner/java/jNumberPickerDialog.java
+++ b/android_wizard/smartdesigner/java/jNumberPickerDialog.java
@@ -61,7 +61,7 @@ public class jNumberPickerDialog /*extends ...*/ {
 	   int halfParentW = width/2-42;
 	   	   
 	   NumberPicker np = new NumberPicker(controls.activity);	   
-	   np.setId(1);
+	   np.setId(controls.getJavaNewId());
 	   	   	   
        android.widget.RelativeLayout.LayoutParams lparams1 = new android.widget.RelativeLayout.LayoutParams(
        		RelativeLayout.LayoutParams.WRAP_CONTENT,RelativeLayout.LayoutParams.WRAP_CONTENT);     // W,H
@@ -74,7 +74,7 @@ public class jNumberPickerDialog /*extends ...*/ {
 	   	   
 	   Button cancel = new Button(controls.activity);
 	   cancel.setText("Cancel");
-	   cancel.setId(2);
+	   cancel.setId(controls.getJavaNewId());
 	   cancel.setBackgroundColor(Color.TRANSPARENT);
 	   	   
        android.widget.RelativeLayout.LayoutParams lparams2 = new android.widget.RelativeLayout.LayoutParams(halfParentW,

--- a/android_wizard/smartdesigner/java/jOpenGLSurfaceView.java
+++ b/android_wizard/smartdesigner/java/jOpenGLSurfaceView.java
@@ -229,10 +229,7 @@ public class jOpenGLSurfaceView extends SurfaceView implements SurfaceHolder.Cal
  		LAMWCommon.clearLayoutAll();
 	 }      
  	
-     public void SetId(int _id) { //wrapper method pattern ...
-        this.setId(_id);
-     }
-       
+      
     //write others [public] methods code here......
     //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...   
      

--- a/android_wizard/smartdesigner/java/jRadioGroup.java
+++ b/android_wizard/smartdesigner/java/jRadioGroup.java
@@ -50,7 +50,7 @@ public class jRadioGroup extends RadioGroup /*dummy*/ { //please, fix what GUI o
                  if (c >= 0) {
                 	 	
 	                RadioButton rb = (RadioButton) findViewById(checkedId);
-	                
+	                	               
 	                if (rb != null) {
 		                String checkedCaption = (String) rb.getText();
 		
@@ -151,10 +151,6 @@ public class jRadioGroup extends RadioGroup /*dummy*/ { //please, fix what GUI o
 
     public void ClearLayoutAll() {   //TODO Pascal
     	LAMWCommon.clearLayoutAll();
-    }
-
-    public void SetId(int _id) { //wrapper method pattern ...
-        this.setId(_id);
     }
 
     //write others [public] methods code here......
@@ -278,7 +274,7 @@ public class jRadioGroup extends RadioGroup /*dummy*/ { //please, fix what GUI o
 	public void Add(String _radioTitle) {
         // Create a Radio Button for RadioGroup
         RadioButton rb = new RadioButton(controls.activity);
-        rb.setId(this.getId() + mSeedId);
+        rb.setId(controls.getJavaNewId());
         mSeedId = mSeedId +1;
         rb.setText(_radioTitle);
         //rb.setTextColor(Color.BLACK);
@@ -288,7 +284,7 @@ public class jRadioGroup extends RadioGroup /*dummy*/ { //please, fix what GUI o
     public void Add(String _radioTitle, int _color) {
         // Create a Radio Button for RadioGroup
         RadioButton rb = new RadioButton(controls.activity);
-        rb.setId(this.getId() + mSeedId);
+        rb.setId(controls.getJavaNewId());
         mSeedId = mSeedId +1;
         rb.setText(_radioTitle);
         rb.setTextColor(_color);

--- a/android_wizard/smartdesigner/java/jRatingBar.java
+++ b/android_wizard/smartdesigner/java/jRatingBar.java
@@ -131,10 +131,6 @@ public class jRatingBar extends RatingBar { //please, fix what GUI object will b
     	LAMWCommon.clearLayoutAll();
     }
 
-    public void SetId(int _id) { //wrapper method pattern ...
-        this.setId(_id);
-    }
-
     //write others [public] methods code here......
     //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
 

--- a/android_wizard/smartdesigner/java/jSearchView.java
+++ b/android_wizard/smartdesigner/java/jSearchView.java
@@ -164,10 +164,6 @@ public class jSearchView extends SearchView /*dummy*/ { //please, fix what GUI o
     }
 
     //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-    public void SetId(int _id) { //wrapper method pattern ...
-        this.setId(_id);
-    }
-
     public String GetQuery() {
         //CharSequence
         return (String) this.getQuery();

--- a/android_wizard/smartdesigner/java/jSeekBar.java
+++ b/android_wizard/smartdesigner/java/jSeekBar.java
@@ -143,10 +143,6 @@ public class jSeekBar extends SeekBar /*dummy*/ { //please, fix what GUI object 
     	LAMWCommon.clearLayoutAll();
     }
 
-    public void SetId(int _id) { //wrapper method pattern ...
-        this.setId(_id);
-    }
-
     public void SetMax(int _maxProgress) {
         this.setMax(_maxProgress);
     }

--- a/android_wizard/smartdesigner/java/jSpinner.java
+++ b/android_wizard/smartdesigner/java/jSpinner.java
@@ -278,10 +278,6 @@ public class jSpinner extends Spinner /*dummy*/ { //please, fix what GUI object 
     	LAMWCommon.clearLayoutAll();
     }
 
-    public void SetId(int _id) { //wrapper method pattern ...
-        this.setId(_id);
-    }
-
     //write others [public] methods code here......
     //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ..
 

--- a/android_wizard/smartdesigner/java/jSpinner_new.java
+++ b/android_wizard/smartdesigner/java/jSpinner_new.java
@@ -340,10 +340,6 @@ public class jSpinner extends Spinner /*dummy*/ { //please, fix what GUI object 
     	LAMWCommon.clearLayoutAll();
     }
 
-    public void SetId(int _id) { //wrapper method pattern ...
-        this.setId(_id);
-    }
-
     //write others [public] methods code here......
     //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ..
 

--- a/android_wizard/smartdesigner/java/jSurfaceView.java
+++ b/android_wizard/smartdesigner/java/jSurfaceView.java
@@ -139,10 +139,6 @@ public class jSurfaceView  extends SurfaceView  /*dummy*/ { //please, fix what G
     	LAMWCommon.clearLayoutAll();
     }
 
-    public void SetId(int _id) { //wrapper method pattern ...
-        this.setId(_id);
-    }
-
     @Override
     protected void onDraw(Canvas canvas) {
         if (mDrawing)  controls.pOnSurfaceViewDraw(pascalObj, canvas);

--- a/android_wizard/smartdesigner/java/jSwitchButton.java
+++ b/android_wizard/smartdesigner/java/jSwitchButton.java
@@ -98,10 +98,6 @@ public class jSwitchButton extends Switch /*API 14*/ { //please, fix what GUI ob
 	   LAMWCommon.clearLayoutAll();
    }
 
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
-
    //write others [public] methods code here......
    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
    public void SetTextOff(String _caption) {

--- a/android_wizard/smartdesigner/java/jTextureView.java
+++ b/android_wizard/smartdesigner/java/jTextureView.java
@@ -143,10 +143,6 @@ public class jTextureView extends TextureView /*dummy*/ { //please, fix what GUI
  
     //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
     
-    public void SetId(int _id) { //wrapper method pattern ...
-       this.setId(_id);
-    }
-    
     public void IsOpaque() {
     	this.isOpaque();
     }

--- a/android_wizard/smartdesigner/java/jToggleButton.java
+++ b/android_wizard/smartdesigner/java/jToggleButton.java
@@ -102,10 +102,6 @@ public class jToggleButton extends ToggleButton /*dummy*/ { //please, fix what G
 	   LAMWCommon.clearLayoutAll();
    }
 
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
-
    //write others [public] methods code here......
    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
 

--- a/android_wizard/smartdesigner/java/jToolbar.java
+++ b/android_wizard/smartdesigner/java/jToolbar.java
@@ -140,9 +140,6 @@ public class jToolbar extends Toolbar /*dummy*/ { //please, fix what GUI object 
    }
 
    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
    
    private int GetDrawableResourceId(String _resName) {
 		  try {

--- a/android_wizard/smartdesigner/java/jTreeListView.java
+++ b/android_wizard/smartdesigner/java/jTreeListView.java
@@ -1514,10 +1514,7 @@ public class jTreeListView extends TreeViewList {
     }
  
     //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-    public void SetId(int _id) { //wrapper method pattern ...
-       this.setId(_id);
-    }
-
+    
 	public int RootNode() {
 		return ROOT.intValue();
 	}

--- a/android_wizard/smartdesigner/java/jVideoView.java
+++ b/android_wizard/smartdesigner/java/jVideoView.java
@@ -146,9 +146,6 @@ public class jVideoView extends VideoView /*dummy*/ { //please, fix what GUI obj
     }
  
     //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-    public void SetId(int _id) { //wrapper method pattern ...
-       this.setId(_id);
-    }
            
     public void Pause() {
        this.pause();

--- a/android_wizard/smartdesigner/java/jViewFlipper.java
+++ b/android_wizard/smartdesigner/java/jViewFlipper.java
@@ -190,10 +190,7 @@ public class jViewFlipper extends ViewFlipper /*dummy*/ { //please, fix what GUI
    }  
       
    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
-
+   
    public void SetAutoStart(boolean _value) {
       this.setAutoStart(_value);  //true
    }

--- a/android_wizard/smartdesigner/java/jZBarcodeScannerView.java
+++ b/android_wizard/smartdesigner/java/jZBarcodeScannerView.java
@@ -315,10 +315,7 @@ public class jZBarcodeScannerView extends FrameLayout {
     }
 
     //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-    public void SetId(int _id) { //wrapper method pattern ...
-        this.setId(_id);
-    }
-
+    
     private void ReScan() {
         if (barcodeScanned) {
             barcodeScanned = false;

--- a/android_wizard/smartdesigner/java/jcOpenMapView.java
+++ b/android_wizard/smartdesigner/java/jcOpenMapView.java
@@ -222,10 +222,7 @@ public class jcOpenMapView extends MapView implements MapEventsReceiver { //plea
     }
 
     //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-    public void SetId(int _id) { //wrapper method pattern ...
-        this.setId(_id);
-    }
-
+    
     //Faz zoom no mapa
     public void SetZoom(int _zoom) {
         mapController.setZoom((double)_zoom);

--- a/android_wizard/smartdesigner/java/jcSignaturePad.java
+++ b/android_wizard/smartdesigner/java/jcSignaturePad.java
@@ -146,10 +146,7 @@ public class jcSignaturePad extends SignaturePad /*dummy*/ { //please, fix what 
     }
  
     //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-    public void SetId(int _id) { //wrapper method pattern ...
-       this.setId(_id);
-    }
-
+    
     public File getAlbumStorageDir(String albumName) {
         // Get the directory for the user's public pictures directory.
         File file = new File(Environment.getExternalStoragePublicDirectory(

--- a/android_wizard/smartdesigner/java/jsAdMob.java
+++ b/android_wizard/smartdesigner/java/jsAdMob.java
@@ -218,9 +218,6 @@ public class jsAdMob extends FrameLayout /*dummy*/ { //please, fix what GUI obje
 	 LAMWCommon.clearLayoutAll();
    }
 
-   //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
+   //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...   
 
 }

--- a/android_wizard/smartdesigner/java/jsAppBarLayout.java
+++ b/android_wizard/smartdesigner/java/jsAppBarLayout.java
@@ -117,9 +117,6 @@ public class jsAppBarLayout extends AppBarLayout /*dummy*/ { //please, fix what 
    }
 
    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
    
    public void	SetFitsSystemWindows(boolean _value) { //TODO Pascal
 		LAMWCommon.setFitsSystemWindows(_value);

--- a/android_wizard/smartdesigner/java/jsBottomNavigationView.java
+++ b/android_wizard/smartdesigner/java/jsBottomNavigationView.java
@@ -141,9 +141,6 @@ public class jsBottomNavigationView extends BottomNavigationView /*dummy*/ { //p
    }
 
    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
    
    public Menu GetMenu() {
 	      //this.getMenu().add(Menu.NONE, 1, Menu.NONE, "Home").setIcon(R.drawable.ic_home_black_24dp);	      

--- a/android_wizard/smartdesigner/java/jsCardView.java
+++ b/android_wizard/smartdesigner/java/jsCardView.java
@@ -111,9 +111,6 @@ public class jsCardView extends CardView /*dummy*/ { //please, fix what GUI obje
    }
 
    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
    
    /*
     * cardView.setCardBackgroundColor(...);

--- a/android_wizard/smartdesigner/java/jsCollapsingToolbarLayout.java
+++ b/android_wizard/smartdesigner/java/jsCollapsingToolbarLayout.java
@@ -118,9 +118,6 @@ public class jsCollapsingToolbarLayout extends CollapsingToolbarLayout /*dummy*/
    }
 
    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
    
    public void SetScrollFlag(int _collapsingScrollFlag) {   //called in OnJNIPrompt
        

--- a/android_wizard/smartdesigner/java/jsContinuousScrollableImageView.java
+++ b/android_wizard/smartdesigner/java/jsContinuousScrollableImageView.java
@@ -116,9 +116,6 @@ public class jsContinuousScrollableImageView extends ContinuousScrollableImageVi
     }
  
     //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-    public void SetId(int _id) { //wrapper method pattern ...
-       this.setId(_id);
-    }
 
     public int GetDrawableResourceId(String _resName) {
         try {

--- a/android_wizard/smartdesigner/java/jsCoordinatorLayout.java
+++ b/android_wizard/smartdesigner/java/jsCoordinatorLayout.java
@@ -99,10 +99,7 @@ public class jsCoordinatorLayout extends CoordinatorLayout /*dummy*/ { //please,
    }
 
    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
-      
+     
    public void	SetFitsSystemWindows(boolean _value) {
 		LAMWCommon.setFitsSystemWindows(_value);
    }

--- a/android_wizard/smartdesigner/java/jsDrawerLayout.java
+++ b/android_wizard/smartdesigner/java/jsDrawerLayout.java
@@ -109,9 +109,6 @@ public class jsDrawerLayout extends DrawerLayout /*dummy*/ { //please, fix what 
    }      
 
    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
    
  //http://abhiandroid.com/materialdesign/navigation-drawer
  

--- a/android_wizard/smartdesigner/java/jsFloatingActionButton.java
+++ b/android_wizard/smartdesigner/java/jsFloatingActionButton.java
@@ -110,10 +110,6 @@ public class jsFloatingActionButton extends FloatingActionButton /*dummy*/ { //p
    }
 
    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
-
    public void SetVisibility(int _value) {  //	   
 	  this.setVisibility(_value);   //View.GONE=8   View.VISIBLE=0  View.INVISIBLE=4
    }

--- a/android_wizard/smartdesigner/java/jsFloatingButton.java
+++ b/android_wizard/smartdesigner/java/jsFloatingButton.java
@@ -111,10 +111,7 @@ public class jsFloatingButton extends FloatingActionButton /*dummy*/ { //please,
    }
 
    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
-
+   
    public void SetVisibility(int _value) {  //	   
 	  this.setVisibility(_value);   //View.GONE=8   View.VISIBLE=0  View.INVISIBLE=4
    }

--- a/android_wizard/smartdesigner/java/jsNavigationView.java
+++ b/android_wizard/smartdesigner/java/jsNavigationView.java
@@ -182,9 +182,6 @@ public class jsNavigationView extends NavigationView /*dummy*/ { //please, fix w
    }
 
    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
       
    public Menu GetMenu() {
       return this.getMenu();
@@ -393,16 +390,14 @@ public class jsNavigationView extends NavigationView /*dummy*/ { //please, fix w
 	      headerLayout.setBackgroundColor(headerColor);
 	      headerImageView = new ImageView(context);
 
-	      int id1 = 111111111;
 	      if (bmp != null) { 	    	  
 	    	  headerImageView.setImageBitmap(bmp);	      
 	          headerImageView.setPadding(10, 10, 10, 10);
-	          headerImageView.setId(id1);
+	          headerImageView.setId(controls.getJavaNewId());
           }
-
-	      int id2 = 111111110;
+	      
 		  headerTextView = new TextView(context);
-		  headerTextView.setId(id2);
+		  headerTextView.setId(controls.getJavaNewId());
 		  headerTextView.setText(headerText);      
 		  headerTextView.setPadding(10, 30, 10, 10);	      		  
 		  headerTextView.setTextColor(textColor);
@@ -415,7 +410,7 @@ public class jsNavigationView extends NavigationView /*dummy*/ { //please, fix w
 
 		  RelativeLayout.LayoutParams paramText = new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
 		  paramText.addRule(RelativeLayout.CENTER_HORIZONTAL);
-		  paramText.addRule(RelativeLayout.BELOW, id1);
+		  paramText.addRule(RelativeLayout.BELOW, headerImageView.getId());
 		  headerLayout.addView(headerTextView, paramText);	    	  
 
 		  if (countText >= 2) {
@@ -425,7 +420,7 @@ public class jsNavigationView extends NavigationView /*dummy*/ { //please, fix w
      	      headerSubTextView.setTextColor(subTextColor);        	  
     		  RelativeLayout.LayoutParams paramText2 = new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
     		  paramText2.addRule(RelativeLayout.CENTER_HORIZONTAL);
-    		  paramText2.addRule(RelativeLayout.BELOW, id2);
+    		  paramText2.addRule(RelativeLayout.BELOW, headerTextView.getId());
     	      headerLayout.addView(headerSubTextView, paramText2);	    	  
 	      }
 
@@ -456,16 +451,14 @@ public class jsNavigationView extends NavigationView /*dummy*/ { //please, fix w
 		headerLayout.setLayoutParams(paramLayout);
 		headerImageView = new ImageView(context);
 
-		int id1 = 111111111;
 		if (bmp != null) {
 			headerImageView.setImageBitmap(bmp);
 			headerImageView.setPadding(10, 10, 10, 10);
-			headerImageView.setId(id1);
+			headerImageView.setId(controls.getJavaNewId());
 		}
-
-		int id2 = 111111110;
+		
 		headerTextView = new TextView(context);
-		headerTextView.setId(id2);
+		headerTextView.setId(controls.getJavaNewId());
 		headerTextView.setText(headerText);
 		headerTextView.setPadding(10, 30, 10, 10);
 		headerTextView.setTextColor(textColor);
@@ -478,7 +471,7 @@ public class jsNavigationView extends NavigationView /*dummy*/ { //please, fix w
 
 		RelativeLayout.LayoutParams paramText = new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
 		paramText.addRule(RelativeLayout.CENTER_HORIZONTAL);
-		paramText.addRule(RelativeLayout.BELOW, id1);
+		paramText.addRule(RelativeLayout.BELOW, headerImageView.getId());
 		headerLayout.addView(headerTextView, paramText);
 
 		if (countText >= 2) {
@@ -488,7 +481,7 @@ public class jsNavigationView extends NavigationView /*dummy*/ { //please, fix w
 			headerSubTextView.setTextColor(subTextColor);
 			RelativeLayout.LayoutParams paramText2 = new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
 			paramText2.addRule(RelativeLayout.CENTER_HORIZONTAL);
-			paramText2.addRule(RelativeLayout.BELOW, id2);
+			paramText2.addRule(RelativeLayout.BELOW, headerTextView.getId());
 			headerLayout.addView(headerSubTextView, paramText2);
 		}
 

--- a/android_wizard/smartdesigner/java/jsNestedScrollView.java
+++ b/android_wizard/smartdesigner/java/jsNestedScrollView.java
@@ -103,10 +103,7 @@ public class jsNestedScrollView extends NestedScrollView /*dummy*/ { //please, f
    }
 
    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
-
+   
    public void SetAppBarLayoutScrollingViewBehavior() { //This attribute will trigger event in the Toolbar.
      CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams)this.getLayoutParams();
      params.setBehavior(new AppBarLayout.ScrollingViewBehavior(context, null));

--- a/android_wizard/smartdesigner/java/jsRecyclerView.java
+++ b/android_wizard/smartdesigner/java/jsRecyclerView.java
@@ -366,7 +366,7 @@ class RecyclerViewAdapter extends RecyclerView.Adapter<RecyclerViewAdapter.Recyc
     public View getlayoutView(Context ctx, String holderItemFormat) {
     	
        RelativeLayout layout = new RelativeLayout(ctx);       
-       layout.setId(1234567);
+       layout.setId(controls.getJavaNewId());
               
        RelativeLayout drafPanel = null;
               
@@ -404,7 +404,7 @@ class RecyclerViewAdapter extends RecyclerView.Adapter<RecyclerViewAdapter.Recyc
 				TextView drafTextView = (TextView)mDraftLayoutView.findViewById(idText);
 				
 				label[indexText] = new TextView(context);				
-				label[indexText].setId(idText);
+				label[indexText].setId(idText);				
 				
 				ViewGroup.LayoutParams lp = (ViewGroup.LayoutParams) drafTextView.getLayoutParams();
 								
@@ -443,6 +443,7 @@ class RecyclerViewAdapter extends RecyclerView.Adapter<RecyclerViewAdapter.Recyc
 				
 				image[indexImage] = new ImageView(context);				
 				image[indexImage].setId(idImage);
+								
 				image[indexImage].setLayoutParams(drafImageView.getLayoutParams());
 			
 				String pad = (String) drafImageView.getTag(); //seted in "jImageView.java"
@@ -463,6 +464,7 @@ class RecyclerViewAdapter extends RecyclerView.Adapter<RecyclerViewAdapter.Recyc
 
 			   check[indexCheck] = new CheckBox(context);
 			   check[indexCheck].setId(idCheck);
+			   
 			   check[indexCheck].setLayoutParams(draftCheckBox.getLayoutParams());
 
 			   String pad = (String) draftCheckBox.getTag(); //seted in "jCheckBox.java"
@@ -495,6 +497,7 @@ class RecyclerViewAdapter extends RecyclerView.Adapter<RecyclerViewAdapter.Recyc
 				   rating[indexRating] = new RatingBar(context, null, android.R.attr.ratingBarStyle);
 
 			   rating[indexRating].setId(idRat);
+			   
 			   rating[indexRating].setStepSize(draftRatingBar.getStepSize());
      	       rating[indexRating].setIsIndicator(draftRatingBar.isIndicator());
 
@@ -524,6 +527,7 @@ class RecyclerViewAdapter extends RecyclerView.Adapter<RecyclerViewAdapter.Recyc
 
 			   switchbtn[indexSwitchbtn] = new Switch(context);
 			   switchbtn[indexSwitchbtn].setId(idSwitch);
+			   
 			   switchbtn[indexSwitchbtn].setLayoutParams(draftSwitch.getLayoutParams());
 
 			   String pad = (String) draftSwitch.getTag(); //seted in "jSwitchButton.java"
@@ -562,7 +566,7 @@ class RecyclerViewAdapter extends RecyclerView.Adapter<RecyclerViewAdapter.Recyc
 	       cardView.setUseCompatPadding(true);	       
 	       cardView.setContentPadding(10, 10,10, 10);
 	       cardView.setPadding(30, 40, 30, 40);	       
-	       cardView.setId(12345678);                    
+	       cardView.setId(controls.getJavaNewId()); 
 	       cardView.addView(layout);                                  
 	       return cardView; 
 	   }	   
@@ -1130,9 +1134,6 @@ public class jsRecyclerView extends RecyclerView /*dummy*/ { //please, fix what 
    }
 
    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
    
    public void SetItemContentDictionary(String _delimitedContentDictionary, String _delimiter) {
 	   rcAdapter.setItemContentDictionary(_delimitedContentDictionary, _delimiter);

--- a/android_wizard/smartdesigner/java/jsTabLayout.java
+++ b/android_wizard/smartdesigner/java/jsTabLayout.java
@@ -134,9 +134,6 @@ public class jsTabLayout extends TabLayout /*dummy*/ { //please, fix what GUI ob
    }
 
    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
       
    public int AddTab(String _title) {
 	  Tab t =  this.newTab().setText(_title);

--- a/android_wizard/smartdesigner/java/jsTextInput.java
+++ b/android_wizard/smartdesigner/java/jsTextInput.java
@@ -142,10 +142,6 @@ public class jsTextInput extends TextInputLayout /*dummy*/ { //please, fix what 
    }
 
    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
-
    public void SetHint(String _hint) {	   
 	   this.setHint(_hint);
    }

--- a/android_wizard/smartdesigner/java/jsToolbar.java
+++ b/android_wizard/smartdesigner/java/jsToolbar.java
@@ -136,9 +136,6 @@ public class jsToolbar extends Toolbar /*dummy*/ { //please, fix what GUI object
    }
 
    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
    
    private int GetDrawableResourceId(String _resName) {
 		  try {

--- a/android_wizard/smartdesigner/java/jsViewPager.java
+++ b/android_wizard/smartdesigner/java/jsViewPager.java
@@ -210,10 +210,7 @@ public class jsViewPager extends ViewPager /*dummy*/ { //please, fix what GUI ob
    }
 
    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...
-   public void SetId(int _id) { //wrapper method pattern ...
-      this.setId(_id);
-   }
-      
+     
    public void AddPage(View _view, String _title) {	   
 	  ViewGroup parent = (ViewGroup) _view.getParent();
 	  if (parent != null) parent.removeView(_view);	   

--- a/ide_tools/ufrmcompcreate.pas
+++ b/ide_tools/ufrmcompcreate.pas
@@ -639,11 +639,6 @@ begin
      strList.Add('	 LAMWCommon.clearLayoutAll();');
      strList.Add('    }');
      strList.Add(' ');
-     strList.Add('    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...');
-     strList.Add('    public void SetId(int _id) { //wrapper method pattern ...');
-     strList.Add('       this.setId(_id);');
-     strList.Add('    }');
-     strList.Add(' ');
      strList.Add('}');
 
      SynMemo1.Clear;
@@ -814,6 +809,9 @@ begin
 
     if Pos('jVisualControl', FProjectModel) > 0  then
     begin
+      listPascal.Add(' ');
+      listPascal.Add('  if gapp <> nil then FId := gapp.GetNewId();');
+      listPascal.Add(' ');
       listPascal.Add('  FMarginLeft   := 10;');
       listPascal.Add('  FMarginTop    := 10;');
       listPascal.Add('  FMarginBottom := 10;');
@@ -1886,14 +1884,8 @@ begin
          strList.Add('    }');
       end;
       strList.Add(' ');
-      strList.Add('    //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...');
+      strList.Add('  //GUIDELINE: please, preferentially, init all yours params names with "_", ex: int _flag, String _hello ...');
       strList.Add('  //write others [public] methods code here......');
-      if codeFrom = 1 then
-      begin
-        strList.Add('    public void SetId(int _id) { //wrapper method pattern ...');
-        strList.Add('       this.setId(_id);');
-        strList.Add('    }');
-      end;
       strList.Add(' ');
 
       //add test here:


### PR DESCRIPTION
If two or more components match the same identification, the application will die horribly. If it is not at the beginning of the activity, it will be when you restart the application and restore your activity. In this way, LAMW manages the ids, preventing any component from having the same id.

I have assigned a range from 1 to 100000 for component ids assigned from Lazarus and 100000 onwards for components assigned by Java. It can be changed if necessary in "Controls.java".

I have tested this change in different LAMW sample applications by adapting the code of JDBListView, jExpanedableListView, jListView, jModalDialog, jNumberPickerDialog, jRadioGroup, jsNavigationView, jsRecyclerView for proper operation and assignment of the correct ids.