### PR TITLE
Updated "jsAdMob" to 17.2.1 by [by ADiV]

### DIFF
--- a/android_wizard/smartdesigner/java/jsAdMob.java
+++ b/android_wizard/smartdesigner/java/jsAdMob.java
@@ -115,8 +115,11 @@ public class jsAdMob extends FrameLayout {
    }
    
    public void AdMobInit(){
-	   MobileAds.initialize(controls.activity);
-	   admobInit = true;
+	  
+	   if( !admobInit ) { 
+	    MobileAds.initialize(controls.activity);
+	    admobInit = true;
+	   }
    }
    
    public void AdMobFree(){

--- a/android_wizard/smartdesigner/java/jsAdMod.dependencies
+++ b/android_wizard/smartdesigner/java/jsAdMod.dependencies
@@ -1,1 +1,0 @@
-compile 'com.google.android.gms:play-services-ads:11.0.4'


### PR DESCRIPTION
Updated to be compatible with AdMob 17.2.1, the example has also been updated. Since the "AndroidManifest.xml" with the app id must be updated for this new version.