### PR TITLE
Fix package by Tomash

### DIFF
--- a/android_bridges/And_jni_Bridge.pas
+++ b/android_bridges/And_jni_Bridge.pas
@@ -820,6 +820,9 @@ Procedure jCanvas_drawBackground       (env:PJNIEnv;
                                         Canv : jObject; _color : DWord);
 Procedure jCanvas_setTextSize          (env:PJNIEnv;
                                         Canv : jObject; textsize : single);
+
+Procedure jCanvas_rotate                (env:PJNIEnv; Canv : jObject; rotation : single); //by Tomash
+
 Procedure jCanvas_SetTypeface          (env:PJNIEnv;
                                         Canv : jObject; _typeface: integer);
 Procedure jCanvas_drawText             (env:PJNIEnv;
@@ -893,6 +896,8 @@ Procedure jBitmap_getWH                (env:PJNIEnv;
 function jBitmap_GetWidth(env: PJNIEnv; bmap: JObject): integer;
 function jBitmap_GetHeight(env: PJNIEnv; bmap: JObject): integer;
 Function  jBitmap_jInstance(env:PJNIEnv;  bmap: jObject): jObject;
+Function  jBitmap_GetCanvas(env:PJNIEnv; bmap: jObject): jObject;//by Tomash
+procedure jBitmap_GetBitmapSizeFromFile(env:PJNIEnv; bmap: jObject; _fullPathFile: string; var w, h :integer);//by Tomash
 function jBitmap_LoadFromAssets(env: PJNIEnv; _jbitmap: JObject; strName: string): jObject;
 procedure jBitmap_LoadFromBuffer(env: PJNIEnv; _jbitmap: JObject; buffer: PJByte; size: Integer);overload;//by Kordal
 function jBitmap_LoadFromBuffer(env: PJNIEnv; _jbitmap: JObject; var buffer: TDynArrayOfJByte): jObject;overload;
@@ -2196,23 +2201,8 @@ Procedure jEditText_setParent(env:PJNIEnv;
 
 //by jmpessoa
 Function jEditText_getText(env:PJNIEnv; EditText : jObject) : String;
-var
-  _jMethod : jMethodID = nil;
-  _jString : jString;
-  _jBoolean: jBoolean;
-  cls: jClass;
 begin
-  cls := env^.GetObjectClass(env, EditText);
-  _jMethod:= env^.GetMethodID(env, cls, 'GetText', '()Ljava/lang/String;');
-  _jString   := env^.CallObjectMethod(env,EditText,_jMethod);
-  case _jString = nil of
-   True : Result    := '';
-   False: begin
-           _jBoolean := JNI_False;
-           Result    := string(env^.GetStringUTFChars(env,_jString,@_jBoolean));
-          end;
-  end;
-  env^.DeleteLocalRef(env, cls);
+  Result:= jni_func_out_t(env, EditText, 'GetText');
 end;
 
 Procedure jEditText_setText(env:PJNIEnv;  EditText: jObject; Str: String);
@@ -5763,25 +5753,8 @@ begin
 end;
 
 function jListView_GetItemText(env:PJNIEnv; ListView : jObject; index: integer): String;
-var
-  _jMethod : jMethodID = nil;
-  _jString : jString;
-  _jBoolean: jBoolean;
-  cls: jClass;
-   _jParams : array[0..0] of jValue;
 begin
-   _jParams[0].i:= index;
-  cls := env^.GetObjectClass(env, ListView);
-  _jMethod:= env^.GetMethodID(env, cls, 'getItemText', '(I)Ljava/lang/String;');
-  _jString   := env^.CallObjectMethodA(env,ListView,_jMethod, @_jParams);
-  Case _jString = nil of
-   True : Result    := '';
-   False: begin
-            _jBoolean := JNI_False;
-            Result    := String( env^.GetStringUTFChars(env,_jString,@_jBoolean) );
-          end;
-  end;
-  env^.DeleteLocalRef(env, cls);
+  Result:= jni_func_i_out_t(env, ListView, 'getItemText', index);
 end;
 
 function jListView_GetCount(env:PJNIEnv;  ListView : jObject): integer;
@@ -5900,23 +5873,8 @@ end;
 
 
 function jListView_GetItemCaption(env: PJNIEnv; _jlistview: JObject): string;
-var
-  jStr: JString;
-  jBoo: JBoolean;
-  jMethod: jMethodID=nil;
-  jCls: jClass=nil;
 begin
-  jCls:= env^.GetObjectClass(env, _jlistview);
-  jMethod:= env^.GetMethodID(env, jCls, 'GetItemCaption', '()Ljava/lang/String;');
-  jStr:= env^.CallObjectMethod(env, _jlistview, jMethod);
-  case jStr = nil of
-     True : Result:= '';
-     False: begin
-              jBoo:= JNI_False;
-              Result:= string( env^.GetStringUTFChars(env, jStr, @jBoo));
-            end;
-  end;
-  env^.DeleteLocalRef(env, jCls);
+  Result:= jni_func_out_t(env, _jlistview, 'GetItemCaption');
 end;
 
 procedure jListView_SetDispatchOnDrawItemTextColor(env: PJNIEnv; _jlistview: JObject; _value: boolean);
@@ -5972,25 +5930,8 @@ begin
 end;
 
 function jListView_GetWidgetText(env: PJNIEnv; _jlistview: JObject; _index: integer): string;
-var
-  jStr: JString;
-  jBoo: JBoolean;
-  jParams: array[0..0] of jValue;
-  jMethod: jMethodID=nil;
-  jCls: jClass=nil;
 begin
-  jParams[0].i:= _index;
-  jCls:= env^.GetObjectClass(env, _jlistview);
-  jMethod:= env^.GetMethodID(env, jCls, 'GetWidgetText', '(I)Ljava/lang/String;');
-  jStr:= env^.CallObjectMethodA(env, _jlistview, jMethod, @jParams);
-  case jStr = nil of
-     True : Result:= '';
-     False: begin
-              jBoo:= JNI_False;
-              Result:= string( env^.GetStringUTFChars(env, jStr, @jBoo));
-            end;
-  end;
-  env^.DeleteLocalRef(env, jCls);
+  Result:= jni_func_i_out_t(env, _jlistview, 'GetWidgetText', _index);
 end;
 
 procedure jListView_setWidgetCheck(env: PJNIEnv; _jlistview: JObject; _value: boolean; _index: integer);
@@ -6066,25 +6007,8 @@ env^.DeleteLocalRef(env,jParams[0].l);
 end;
 
 function jListView_getItemTagString(env: PJNIEnv; _jlistview: JObject; _index: integer): string;
-var
-  jStr: JString;
-  jBoo: JBoolean;
-  jParams: array[0..0] of jValue;
-  jMethod: jMethodID=nil;
-  jCls: jClass=nil;
 begin
-  jParams[0].i:= _index;
-  jCls:= env^.GetObjectClass(env, _jlistview);
-  jMethod:= env^.GetMethodID(env, jCls, 'getItemTagString', '(I)Ljava/lang/String;');
-  jStr:= env^.CallObjectMethodA(env, _jlistview, jMethod, @jParams);
-  case jStr = nil of
-     True : Result:= '';
-     False: begin
-              jBoo:= JNI_False;
-              Result:= string( env^.GetStringUTFChars(env, jStr, @jBoo));
-            end;
-  end;
-  env^.DeleteLocalRef(env, jCls);
+  Result:= jni_func_i_out_t(env, _jlistview, 'getItemTagString', _index);
 end;
 
 
@@ -6178,73 +6102,19 @@ begin
 end;
 
 function jListView_GetCenterItemCaption(env: PJNIEnv; _jlistview: JObject; _fullItemCaption: string): string;
-var
-  jStr: JString;
-  jBoo: JBoolean;
-  jParams: array[0..0] of jValue;
-  jMethod: jMethodID=nil;
-  jCls: jClass=nil;
 begin
-  jParams[0].l:= env^.NewStringUTF(env, PChar(_fullItemCaption));
-  jCls:= env^.GetObjectClass(env, _jlistview);
-  jMethod:= env^.GetMethodID(env, jCls, 'GetCenterItemCaption', '(Ljava/lang/String;)Ljava/lang/String;');
-  jStr:= env^.CallObjectMethodA(env, _jlistview, jMethod, @jParams);
-  case jStr = nil of
-     True : Result:= '';
-     False: begin
-              jBoo:= JNI_False;
-              Result:= string( env^.GetStringUTFChars(env, jStr, @jBoo));
-            end;
-  end;
-  env^.DeleteLocalRef(env,jParams[0].l);
-  env^.DeleteLocalRef(env, jCls);
+  Result:= jni_func_t_out_t(env, _jlistview, 'GetCenterItemCaption', _fullItemCaption);
 end;
 
 
 function jListView_GetLeftItemCaption(env: PJNIEnv; _jlistview: JObject; _fullItemCaption: string): string;
-var
-  jStr: JString;
-  jBoo: JBoolean;
-  jParams: array[0..0] of jValue;
-  jMethod: jMethodID=nil;
-  jCls: jClass=nil;
 begin
-  jParams[0].l:= env^.NewStringUTF(env, PChar(_fullItemCaption));
-  jCls:= env^.GetObjectClass(env, _jlistview);
-  jMethod:= env^.GetMethodID(env, jCls, 'GetLeftItemCaption', '(Ljava/lang/String;)Ljava/lang/String;');
-  jStr:= env^.CallObjectMethodA(env, _jlistview, jMethod, @jParams);
-  case jStr = nil of
-     True : Result:= '';
-     False: begin
-              jBoo:= JNI_False;
-              Result:= string( env^.GetStringUTFChars(env, jStr, @jBoo));
-            end;
-  end;
-  env^.DeleteLocalRef(env,jParams[0].l);
-  env^.DeleteLocalRef(env, jCls);
+  Result:= jni_func_t_out_t(env, _jlistview, 'GetLeftItemCaption', _fullItemCaption);
 end;
 
 function jListView_GetRightItemCaption(env: PJNIEnv; _jlistview: JObject; _fullItemCaption: string): string;
-var
-  jStr: JString;
-  jBoo: JBoolean;
-  jParams: array[0..0] of jValue;
-  jMethod: jMethodID=nil;
-  jCls: jClass=nil;
 begin
-  jParams[0].l:= env^.NewStringUTF(env, PChar(_fullItemCaption));
-  jCls:= env^.GetObjectClass(env, _jlistview);
-  jMethod:= env^.GetMethodID(env, jCls, 'GetRightItemCaption', '(Ljava/lang/String;)Ljava/lang/String;');
-  jStr:= env^.CallObjectMethodA(env, _jlistview, jMethod, @jParams);
-  case jStr = nil of
-     True : Result:= '';
-     False: begin
-              jBoo:= JNI_False;
-              Result:= string( env^.GetStringUTFChars(env, jStr, @jBoo));
-            end;
-  end;
-  env^.DeleteLocalRef(env,jParams[0].l);
-  env^.DeleteLocalRef(env, jCls);
+  Result:= jni_func_t_out_t(env, _jlistview, 'GetRightItemCaption', _fullItemCaption);
 end;
 
 function jListView_GetLongPressSelectedItem(env: PJNIEnv; _jlistview: JObject): integer;
@@ -9571,6 +9441,20 @@ env^.DeleteLocalRef(env,jParams[0].l);
   env^.DeleteLocalRef(env, jCls);
 end;
 
+//by Tomash
+Procedure jCanvas_rotate(env:PJNIEnv; Canv : jObject; rotation : single );
+Var
+ _jMethod : jMethodID = nil;
+ _jParams : Array[0..0] of jValue;
+    cls: jClass;
+begin
+ _jParams[0].f := rotation;
+ cls := env^.GetObjectClass(env, Canv);
+_jMethod:= env^.GetMethodID(env, cls, 'rotate', '(F)V');
+ env^.CallVoidMethodA(env,Canv,_jMethod,@_jParams);
+ env^.DeleteLocalRef(env, cls);
+end;
+
 //------------------------------------------------------------------------------
 // Bitmap
 //------------------------------------------------------------------------------
@@ -9696,6 +9580,44 @@ begin
   cls := env^.GetObjectClass(env, bmap);
   _jMethod:= env^.GetMethodID(env, cls,'jInstance', '()Landroid/graphics/Bitmap;');
   Result := env^.CallObjectMethod(env,bmap,_jMethod);
+  env^.DeleteLocalRef(env, cls);
+end;
+
+//by Tomash
+Function  jBitmap_GetCanvas(env:PJNIEnv; bmap: jObject): jObject;
+var
+  _jMethod : jMethodID = nil;
+  cls: jClass;
+begin
+  cls := env^.GetObjectClass(env, bmap);
+  _jMethod:= env^.GetMethodID(env, cls,'GetCanvas', '()Landroid/graphics/Canvas;');
+  Result := env^.CallObjectMethod(env,bmap,_jMethod);
+  env^.DeleteLocalRef(env, cls);
+end;
+
+//by Tomash
+procedure jBitmap_GetBitmapSizeFromFile(env:PJNIEnv; bmap: jObject; _fullPathFile: string; var w, h :integer);
+var
+  jParams: array[0..0] of jValue;
+  _jMethod   : jMethodID = nil;
+  _jIntArray : jintArray;
+  _jBoolean  : jBoolean;
+  PInt       : PInteger;
+  PIntSav    : PInteger;
+  cls: jClass;
+begin
+  jParams[0].l:= env^.NewStringUTF(env, PChar(_fullPathFile));
+  cls := env^.GetObjectClass(env, bmap);
+
+  _jMethod:= env^.GetMethodID(env, cls, 'GetBitmapSizeFromFile', '(Ljava/lang/String;)[I');
+  _jIntArray:= env^.CallObjectMethodA(env,bmap,_jMethod, @jParams);
+  _jBoolean  := JNI_False;
+  PInt       := env^.GetIntArrayElements(env,_jIntArray,_jBoolean);
+  PIntSav    := PInt;
+  w          := PInt^; Inc(PInt);
+  h          := PInt^; Inc(PInt);
+  env^.ReleaseIntArrayElements(env,_jIntArray,PIntSav,0);
+  env^.DeleteLocalRef(env,jParams[0].l);
   env^.DeleteLocalRef(env, cls);
 end;
 
@@ -10132,7 +10054,6 @@ end;
 function jBitmap_GetBase64StringFromImage(env: PJNIEnv; _jbitmap: JObject; _bitmap: jObject; _compressFormat: integer): string;
 var
   jStr: JString;
-  jBoo: JBoolean;
   jParams: array[0..1] of jValue;
   jMethod: jMethodID=nil;
   jCls: jClass=nil;
@@ -10142,13 +10063,7 @@ begin
   jCls:= env^.GetObjectClass(env, _jbitmap);
   jMethod:= env^.GetMethodID(env, jCls, 'GetBase64StringFromImage', '(Landroid/graphics/Bitmap;I)Ljava/lang/String;');
   jStr:= env^.CallObjectMethodA(env, _jbitmap, jMethod, @jParams);
-  case jStr = nil of
-     True : Result:= '';
-     False: begin
-              jBoo:= JNI_False;
-              Result:= string( env^.GetStringUTFChars(env, jStr, @jBoo));
-            end;
-  end;
+  Result:= GetPStringAndDeleteLocalRef(env, jStr);
   env^.DeleteLocalRef(env, jCls);
 end;
 
@@ -10167,26 +10082,8 @@ begin
 end;
 
 function jBitmap_GetBase64StringFromImageFile(env: PJNIEnv; _jbitmap: JObject; _fullPathToImageFile: string): string;
-var
-  jStr: JString;
-  jBoo: JBoolean;
-  jParams: array[0..0] of jValue;
-  jMethod: jMethodID=nil;
-  jCls: jClass=nil;
 begin
-  jParams[0].l:= env^.NewStringUTF(env, PChar(_fullPathToImageFile));
-  jCls:= env^.GetObjectClass(env, _jbitmap);
-  jMethod:= env^.GetMethodID(env, jCls, 'GetBase64StringFromImageFile', '(Ljava/lang/String;)Ljava/lang/String;');
-  jStr:= env^.CallObjectMethodA(env, _jbitmap, jMethod, @jParams);
-  case jStr = nil of
-     True : Result:= '';
-     False: begin
-              jBoo:= JNI_False;
-              Result:= string( env^.GetStringUTFChars(env, jStr, @jBoo));
-            end;
-  end;
-  env^.DeleteLocalRef(env,jParams[0].l);
-  env^.DeleteLocalRef(env, jCls);
+  Result:= jni_func_t_out_t(env, _jbitmap, 'GetBase64StringFromImageFile', _fullPathToImageFile);
 end;
 
 
@@ -11537,25 +11434,8 @@ begin
 end;
 
 Function jSqliteCursor_GetColumName(env:PJNIEnv;  SqliteCursor: jObject; columnIndex: integer): string;
-var
- _jMethod : jMethodID = nil;
- cls: jClass;
- _jParam: array[0..0] of jValue;
- _jString  : jString;
- _jBoolean : jBoolean;
 begin
-  _jParam[0].i := columnIndex;
-  cls := env^.GetObjectClass(env, SqliteCursor);
-  _jMethod:= env^.GetMethodID(env, cls, 'GetColumName', '(I)Ljava/lang/String;');
-  _jString   := env^.CallObjectMethodA(env,SqliteCursor,_jMethod,@_jParam);
-  case _jString = nil of
-    True : Result    := '';
-    False: begin
-            _jBoolean := JNI_False;
-            Result    := String( env^.GetStringUTFChars(env,_jString,@_jBoolean) );
-           end;
-  end;
-  env^.DeleteLocalRef(env, cls);
+  Result:= jni_func_i_out_t(env, SqliteCursor, 'GetColumName', columnIndex);
 end;
 
 Function jSqliteCursor_GetColumnIndex(env:PJNIEnv;  SqliteCursor: jObject; colName: string): integer;
@@ -11588,29 +11468,8 @@ end;
 //fixed by Martin Lowry
 
 Function jSqliteCursor_GetValueAsString(env:PJNIEnv;  SqliteCursor: jObject; columnIndex: integer): string;
-var
- _jMethod : jMethodID = nil;
- cls: jClass;
- _jParam: array[0..0] of jValue;
-  _jString  : jString;
- _jBoolean : jBoolean;
- tmp:pchar;
 begin
-  _jParam[0].i := columnIndex;
-  cls := env^.GetObjectClass(env, SqliteCursor);
-  _jMethod:= env^.GetMethodID(env, cls, 'GetValueAsString', '(I)Ljava/lang/String;');
-  _jString   := env^.CallObjectMethodA(env,SqliteCursor,_jMethod,@_jParam);
-  case _jString = nil of
-    True : Result    := '';
-    False: begin
-            _jBoolean := JNI_False;
-            tmp    := env^.GetStringUTFChars(Env, _jString, @_jBoolean);
-            Result := AnsiString( tmp );
-            env^.ReleaseStringUTFChars(env, _jString, tmp);
-            env^.DeleteLocalRef(env, _jString);
-          end;
-  end;
-  env^.DeleteLocalRef(env, cls);
+  Result:= jni_func_i_out_t(env, SqliteCursor, 'GetValueAsString', columnIndex);
 end;
 
 
@@ -11667,29 +11526,8 @@ begin
 end;
 
 Function jSqliteCursor_GetValueToString(env:PJNIEnv;  SqliteCursor: jObject; columnIndex: integer): string;
-var
- _jMethod : jMethodID = nil;
- cls: jClass;
- _jParam: array[0..0] of jValue;
-  _jString  : jString;
- _jBoolean : jBoolean;
- tmp:pchar;
 begin
-  _jParam[0].i := columnIndex;
-  cls := env^.GetObjectClass(env, SqliteCursor);
-  _jMethod:= env^.GetMethodID(env, cls, 'GetValueToString', '(I)Ljava/lang/String;');
-  _jString   := env^.CallObjectMethodA(env,SqliteCursor,_jMethod,@_jParam);
-  case _jString = nil of
-    True : Result    := '';
-    False: begin
-            _jBoolean := JNI_False;
-            tmp    := env^.GetStringUTFChars(Env, _jString, @_jBoolean);
-            Result := AnsiString( tmp );
-            env^.ReleaseStringUTFChars(env, _jString, tmp);
-            env^.DeleteLocalRef(env, _jString);
-          end;
-  end;
-  env^.DeleteLocalRef(env, cls);
+  Result:= jni_func_i_out_t(env, SqliteCursor, 'GetValueToString', columnIndex);
 end;
 
 function jSqliteCursor_GetPosition(env: PJNIEnv; SqliteCursor: JObject): integer;
@@ -11853,26 +11691,8 @@ begin
 end;
 
 function jSqliteDataAccess_Select(env: PJNIEnv; _jsqlitedataaccess: JObject; selectQuery: string): string;
-var
-  jStr: JString;
-  jBoo: JBoolean;
-  jParams: array[0..0] of jValue;
-  jMethod: jMethodID=nil;
-  jCls: jClass=nil;
 begin
-  jParams[0].l:= env^.NewStringUTF(env, PChar(selectQuery));
-  jCls:= env^.GetObjectClass(env, _jsqlitedataaccess);
-  jMethod:= env^.GetMethodID(env, jCls, 'Select', '(Ljava/lang/String;)Ljava/lang/String;');
-  jStr:= env^.CallObjectMethodA(env, _jsqlitedataaccess, jMethod, @jParams);
-  case jStr = nil of
-     True : Result:= '';
-     False: begin
-              jBoo:= JNI_False;
-              Result:= string( env^.GetStringUTFChars(env, jStr, @jBoo));
-            end;
-  end;
-  env^.DeleteLocalRef(env,jParams[0].l);
-  env^.DeleteLocalRef(env, jCls);
+  Result:= jni_func_t_out_t(env, _jsqlitedataaccess, 'Select', selectQuery);
 end;
 
 
@@ -12684,24 +12504,8 @@ end;
 
 
    function jDBListView_GetItemCaption(env: PJNIEnv; _jdblistview: JObject): string;
-   var
-     jStr: JString;
-     jBoo: JBoolean;
-     jMethod: jMethodID = nil;
-     jCls: jClass = nil;
    begin
-     jCls := env^.GetObjectClass(env, _jdblistview);
-     jMethod := env^.GetMethodID(env, jCls, 'GetItemCaption', '()Ljava/lang/String;');
-     jStr := env^.CallObjectMethod(env, _jdblistview, jMethod);
-     case jStr = nil of
-       True: Result := '';
-       False:
-       begin
-         jBoo := JNI_False;
-         Result := string(env^.GetStringUTFChars(env, jStr, @jBoo));
-       end;
-     end;
-     env^.DeleteLocalRef(env, jCls);
+     Result:= jni_func_out_t(env, _jdblistview, 'GetItemCaption');
    end;
 
 
@@ -12907,27 +12711,8 @@ begin
 end;
 
 function jHTTPClient_Get(env: PJNIEnv; _jHTTPClient: JObject; _Link: string): string;
-  var
-  jParams: array[0..0] of jValue;
-  jMethod: jMethodID = nil;
-  jCls: jClass = nil;
-  jStr: jString;
-  jBool: jBoolean;
 begin
-  jParams[0].l := env^.NewStringUTF(env, PChar(_Link));
-  jCls := env^.GetObjectClass(env, _jHTTPClient);
-  jMethod := env^.GetMethodID(env, jCls, 'Get', '(Ljava/lang/String;)Ljava/lang/String;');
-  jStr := env^.CallObjectMethodA(env, _jHTTPClient, jMethod, @jParams);
-  case jStr = nil of
-    True: Result := '';
-    False:
-    begin
-      jBool := JNI_False;
-      Result := string(env^.GetStringUTFChars(env, jStr, @jBool));
-    end;
-  end;
-  env^.DeleteLocalRef(env, jParams[0].l);
-  env^.DeleteLocalRef(env, jCls);
+  Result:= jni_func_t_out_t(env, _jHTTPClient, 'Get', _Link);
 end;
 
 procedure jHttpClient_SetAuthenticationUser(env: PJNIEnv; _jhttpclient: JObject; _userName: string; _password: string);
@@ -13049,27 +12834,8 @@ begin
 end;
 
 function jHTTPClient_Post(env: PJNIEnv; _jHTTPClient: JObject; _Link: string): string;
-  var
-  jParams: array[0..0] of jValue;
-  jMethod: jMethodID = nil;
-  jCls: jClass = nil;
-  jStr: jString;
-  jBool: jBoolean;
 begin
-  jParams[0].l := env^.NewStringUTF(env, PChar(_Link));
-  jCls := env^.GetObjectClass(env, _jHTTPClient);
-  jMethod := env^.GetMethodID(env, jCls, 'Post', '(Ljava/lang/String;)Ljava/lang/String;');
-  jStr := env^.CallObjectMethodA(env, _jHTTPClient, jMethod, @jParams);
-  case jStr = nil of
-    True: Result := '';
-    False:
-    begin
-      jBool := JNI_False;
-      Result := string(env^.GetStringUTFChars(env, jStr, @jBool));
-    end;
-  end;
-  env^.DeleteLocalRef(env, jParams[0].l);
-  env^.DeleteLocalRef(env, jCls);
+  Result:= jni_func_t_out_t(env, _jHTTPClient, 'Post', _Link);
 end;
 
 function jHttpClient_GetCookiesCount(env: PJNIEnv; _jhttpclient: JObject): integer;
@@ -13100,7 +12866,6 @@ end;
 function jHttpClient_GetCookieAttributeValue(env: PJNIEnv; _jhttpclient: JObject; _cookie: jObject; _attribute: string): string;
 var
   jStr: JString;
-  jBoo: JBoolean;
   jParams: array[0..1] of jValue;
   jMethod: jMethodID=nil;
   jCls: jClass=nil;
@@ -13110,13 +12875,7 @@ begin
   jCls:= env^.GetObjectClass(env, _jhttpclient);
   jMethod:= env^.GetMethodID(env, jCls, 'GetCookieAttributeValue', '(Ljava/net/HttpCookie;Ljava/lang/String;)Ljava/lang/String;');
   jStr:= env^.CallObjectMethodA(env, _jhttpclient, jMethod, @jParams);
-  case jStr = nil of
-     True : Result:= '';
-     False: begin
-              jBoo:= JNI_False;
-              Result:= string( env^.GetStringUTFChars(env, jStr, @jBoo));
-            end;
-  end;
+  Result:= GetPStringAndDeleteLocalRef(env, jStr);
   env^.DeleteLocalRef(env,jParams[1].l);
   env^.DeleteLocalRef(env, jCls);
 end;
@@ -13164,49 +12923,13 @@ begin
 end;
 
 function jHttpClient_GetStateful(env: PJNIEnv; _jhttpclient: JObject; _url: string): string;
-var
-  jStr: JString;
-  jBoo: JBoolean;
-  jParams: array[0..0] of jValue;
-  jMethod: jMethodID=nil;
-  jCls: jClass=nil;
 begin
-  jParams[0].l:= env^.NewStringUTF(env, PChar(_url));
-  jCls:= env^.GetObjectClass(env, _jhttpclient);
-  jMethod:= env^.GetMethodID(env, jCls, 'GetStateful', '(Ljava/lang/String;)Ljava/lang/String;');
-  jStr:= env^.CallObjectMethodA(env, _jhttpclient, jMethod, @jParams);
-  case jStr = nil of
-     True : Result:= '';
-     False: begin
-              jBoo:= JNI_False;
-              Result:= string( env^.GetStringUTFChars(env, jStr, @jBoo));
-            end;
-  end;
-env^.DeleteLocalRef(env,jParams[0].l);
-  env^.DeleteLocalRef(env, jCls);
+  Result:= jni_func_t_out_t(env, _jHTTPClient, 'GetStateful', _url);
 end;
 
 function jHttpClient_PostStateful(env: PJNIEnv; _jhttpclient: JObject; _url: string): string;
-var
-  jStr: JString;
-  jBoo: JBoolean;
-  jParams: array[0..0] of jValue;
-  jMethod: jMethodID=nil;
-  jCls: jClass=nil;
 begin
-  jParams[0].l:= env^.NewStringUTF(env, PChar(_url));
-  jCls:= env^.GetObjectClass(env, _jhttpclient);
-  jMethod:= env^.GetMethodID(env, jCls, 'PostStateful', '(Ljava/lang/String;)Ljava/lang/String;');
-  jStr:= env^.CallObjectMethodA(env, _jhttpclient, jMethod, @jParams);
-  case jStr = nil of
-     True : Result:= '';
-     False: begin
-              jBoo:= JNI_False;
-              Result:= string( env^.GetStringUTFChars(env, jStr, @jBoo));
-            end;
-  end;
-  env^.DeleteLocalRef(env,jParams[0].l);
-  env^.DeleteLocalRef(env, jCls);
+  Result:= jni_func_t_out_t(env, _jHTTPClient, 'PostStateful', _url);
 end;
 
 function jHttpClient_IsCookiePersistent(env: PJNIEnv; _jhttpclient: JObject; _cookie: jObject): boolean;
@@ -13282,13 +13005,7 @@ begin
   jCls:= env^.GetObjectClass(env, _jhttpclient);
   jMethod:= env^.GetMethodID(env, jCls, 'GetCookieValue', '(Ljava/net/HttpCookie;)Ljava/lang/String;');
   jStr:= env^.CallObjectMethodA(env, _jhttpclient, jMethod, @jParams);
-  case jStr = nil of
-     True : Result:= '';
-     False: begin
-              jBoo:= JNI_False;
-              Result:= string( env^.GetStringUTFChars(env, jStr, @jBoo));
-            end;
-  end;
+  Result:= GetPStringAndDeleteLocalRef(env, jStr);
   env^.DeleteLocalRef(env, jCls);
 end;
 
@@ -13304,13 +13021,7 @@ begin
   jCls:= env^.GetObjectClass(env, _jhttpclient);
   jMethod:= env^.GetMethodID(env, jCls, 'GetCookieName', '(Ljava/net/HttpCookie;)Ljava/lang/String;');
   jStr:= env^.CallObjectMethodA(env, _jhttpclient, jMethod, @jParams);
-  case jStr = nil of
-     True : Result:= '';
-     False: begin
-              jBoo:= JNI_False;
-              Result:= string( env^.GetStringUTFChars(env, jStr, @jBoo));
-            end;
-  end;
+  Result:= GetPStringAndDeleteLocalRef(env, jStr);
   env^.DeleteLocalRef(env, jCls);
 end;
 
@@ -13386,7 +13097,6 @@ end;
 function jHttpClient_DeleteStateful(env: PJNIEnv; _jhttpclient: JObject; _url, _value: string): string;
 var
   jStr: JString;
-  jBoo: JBoolean;
   jParams: array[0..1] of jValue;
   jMethod: jMethodID=nil;
   jCls: jClass=nil;
@@ -13396,13 +13106,7 @@ begin
   jCls:= env^.GetObjectClass(env, _jhttpclient);
   jMethod:= env^.GetMethodID(env, jCls, 'DeleteStateful', '(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;');
   jStr:= env^.CallObjectMethodA(env, _jhttpclient, jMethod, @jParams);
-  case jStr = nil of
-     True : Result:= '';
-     False: begin
-              jBoo:= JNI_False;
-              Result:= string( env^.GetStringUTFChars(env, jStr, @jBoo));
-            end;
-  end;
+  Result:= GetPStringAndDeleteLocalRef(env, jStr);
   env^.DeleteLocalRef(env,jParams[0].l);
   env^.DeleteLocalRef(env,jParams[1].l);
   env^.DeleteLocalRef(env, jCls);
@@ -13514,7 +13218,6 @@ end;
 function jHttpClient_GetHeaderField(env: PJNIEnv; _jhttpclient: JObject; _httpConnection: jObject; _headerName: string): string;
 var
   jStr: JString;
-  jBoo: JBoolean;
   jParams: array[0..1] of jValue;
   jMethod: jMethodID=nil;
   jCls: jClass=nil;
@@ -13524,13 +13227,7 @@ begin
   jCls:= env^.GetObjectClass(env, _jhttpclient);
   jMethod:= env^.GetMethodID(env, jCls, 'GetHeaderField', '(Ljava/net/HttpURLConnection;Ljava/lang/String;)Ljava/lang/String;');
   jStr:= env^.CallObjectMethodA(env, _jhttpclient, jMethod, @jParams);
-  case jStr = nil of
-     True : Result:= '';
-     False: begin
-              jBoo:= JNI_False;
-              Result:= string( env^.GetStringUTFChars(env, jStr, @jBoo));
-            end;
-  end;
+  Result:= GetPStringAndDeleteLocalRef(env, jStr);
 env^.DeleteLocalRef(env,jParams[1].l);
   env^.DeleteLocalRef(env, jCls);
 end;
@@ -13587,7 +13284,6 @@ end;
 function jHttpClient_Get(env: PJNIEnv; _jhttpclient: JObject; _httpConnection: jObject): string;
 var
   jStr: JString;
-  jBoo: JBoolean;
   jParams: array[0..0] of jValue;
   jMethod: jMethodID=nil;
   jCls: jClass=nil;
@@ -13596,13 +13292,7 @@ begin
   jCls:= env^.GetObjectClass(env, _jhttpclient);
   jMethod:= env^.GetMethodID(env, jCls, 'Get', '(Ljava/net/HttpURLConnection;)Ljava/lang/String;');
   jStr:= env^.CallObjectMethodA(env, _jhttpclient, jMethod, @jParams);
-  case jStr = nil of
-     True : Result:= '';
-     False: begin
-              jBoo:= JNI_False;
-              Result:= string( env^.GetStringUTFChars(env, jStr, @jBoo));
-            end;
-  end;
+  Result:= GetPStringAndDeleteLocalRef(env, jStr);
   env^.DeleteLocalRef(env, jCls);
 end;
 
@@ -13626,7 +13316,6 @@ end;
 function jHttpClient_Post(env: PJNIEnv; _jhttpclient: JObject; _httpConnection: jObject): string;
 var
   jStr: JString;
-  jBoo: JBoolean;
   jParams: array[0..0] of jValue;
   jMethod: jMethodID=nil;
   jCls: jClass=nil;
@@ -13635,13 +13324,7 @@ begin
   jCls:= env^.GetObjectClass(env, _jhttpclient);
   jMethod:= env^.GetMethodID(env, jCls, 'Post', '(Ljava/net/HttpURLConnection;)Ljava/lang/String;');
   jStr:= env^.CallObjectMethodA(env, _jhttpclient, jMethod, @jParams);
-  case jStr = nil of
-     True : Result:= '';
-     False: begin
-              jBoo:= JNI_False;
-              Result:= string( env^.GetStringUTFChars(env, jStr, @jBoo));
-            end;
-  end;
+  Result:= GetPStringAndDeleteLocalRef(env, jStr);
   env^.DeleteLocalRef(env, jCls);
 end;
 
@@ -13927,7 +13610,6 @@ function jRead_SMS(env:PJNIEnv; this:jobject; intentReceiver: jObject; addressBo
 var
  _jMethod  : jMethodID = nil;
  _jString  : jString;
- _jBoolean : jBoolean;
  _jParams : array[0..1] of jValue;
  jCls: jClass=nil;
 begin
@@ -13936,13 +13618,7 @@ begin
  _jParams[0].l :=  intentReceiver;
  _jParams[1].l := env^.NewStringUTF(env, pchar(addressBodyDelimiter) );
  _jString   := env^.CallObjectMethodA(env,this,_jMethod,@_jParams);
- case _jString = nil of
-  True : Result:= '';
-  False: begin
-          _jBoolean := JNI_False;
-          Result    := string( env^.GetStringUTFChars(Env,_jString,@_jBoolean) );
-         end;
- end;
+ Result:= GetPStringAndDeleteLocalRef(env, _jString);
  env^.DeleteLocalRef(env,_jParams[1].l);
 end;
 
@@ -13950,25 +13626,8 @@ end;
 //by jmpessoa
 function jContact_getMobileNumberByDisplayName(env:PJNIEnv; this:jobject;
                                                contactName: string): string;
-var
- _jMethod  : jMethodID = nil;
- _jString  : jString;
- _jBoolean : jBoolean;
- _jParams : array[0..0] of jValue;
- jCls: jClass=nil;
 begin
- jCls:= Get_gjClass(env);
- _jMethod:= env^.GetMethodID(env, jCls, 'jContact_getMobileNumberByDisplayName', '(Ljava/lang/String;)Ljava/lang/String;');
- _jParams[0].l := env^.NewStringUTF(env, pchar(contactName) );
- _jString   := env^.CallObjectMethodA(env,this,_jMethod,@_jParams);
- case _jString = nil of
-  True : Result    := '';
-  False: begin
-          _jBoolean := JNI_False;
-          Result    := string( env^.GetStringUTFChars(Env,_jString,@_jBoolean) );
-         end;
- end;
- env^.DeleteLocalRef(env,_jParams[0].l);
+ Result:= jni_func_t_out_t(env, this, 'jContact_getMobileNumberByDisplayName', contactName);
 end;
 
 //by jmpessoa
@@ -13984,13 +13643,7 @@ begin
  _jMethod:= env^.GetMethodID(env, jCls, 'jContact_getDisplayNameList', '(C)Ljava/lang/String;');
  _jParams[0].c := jChar(delimiter);
  _jString   := env^.CallObjectMethodA(env,this,_jMethod,@_jParams);
- case _jString = nil of
-  True : Result    := '';
-  False: begin
-          _jBoolean := JNI_False;
-          Result    := string( env^.GetStringUTFChars(Env,_jString,@_jBoolean) );
-         end;
- end;
+ Result:= GetPStringAndDeleteLocalRef(env, _jString);
 end;
 
 //------------------------------------------------------------------------------
@@ -14016,7 +13669,6 @@ var
  _jMethod  : jMethodID = nil;
  _jParams : array[0..1] of jValue;
  _jString  : jString;
- _jBoolean : jBoolean;
   jCls: jClass=nil;
 begin
  jCls:= Get_gjClass(env);
@@ -14024,13 +13676,7 @@ begin
  _jParams[0].l := env^.NewStringUTF(env, pchar(path) );
  _jParams[1].l := env^.NewStringUTF(env, pchar(filename) );
  _jString   := env^.CallObjectMethodA(env,this,_jMethod,@_jParams);
- case _jString = nil of
-  True : Result    := '';
-  False: begin
-          _jBoolean := JNI_False;
-          Result    := string( env^.GetStringUTFChars(Env,_jString,@_jBoolean) );
-         end;
- end;
+ Result:= GetPStringAndDeleteLocalRef(env, _jString);
  env^.DeleteLocalRef(env,_jParams[0].l);
  env^.DeleteLocalRef(env,_jParams[1].l);
 end;
@@ -14040,7 +13686,6 @@ var
  _jMethod  : jMethodID = nil;
  _jParams : array[0..2] of jValue;
  _jString  : jString;
- _jBoolean : jBoolean;
   jCls: jClass=nil;
 begin
  jCls:= Get_gjClass(env);
@@ -14049,13 +13694,7 @@ begin
  _jParams[1].l := env^.NewStringUTF(env, pchar(filename) );
  _jParams[2].i := requestCode;
  _jString   := env^.CallObjectMethodA(env,this,_jMethod,@_jParams);
- case _jString = nil of
-  True : Result    := '';
-  False: begin
-          _jBoolean := JNI_False;
-          Result    := string( env^.GetStringUTFChars(Env,_jString,@_jBoolean) );
-         end;
- end;
+ Result:= GetPStringAndDeleteLocalRef(env, _jString);
  env^.DeleteLocalRef(env,_jParams[0].l);
  env^.DeleteLocalRef(env,_jParams[1].l);
 end;

--- a/android_bridges/bluetooth.pas
+++ b/android_bridges/bluetooth.pas
@@ -53,7 +53,7 @@ jBluetooth = class(jControl)
     function GetReachablePairedDevices(): TDynArrayOfString;
     procedure Disable();
     function IsEnable(): boolean;
-    function GetState(): integer;
+    function GetState(): integer; //STATE_OFF=10, STATE_TURNING_ON=11, STATE_ON=12, STATE_TURNING_OFF=13
 
     function GetReachablePairedDeviceByName(_deviceName: string): jObject;
     function GetReachablePairedDeviceByAddress(_deviceAddress: string): jObject;

--- a/android_bridges/bluetoothclientsocket.pas
+++ b/android_bridges/bluetoothclientsocket.pas
@@ -36,6 +36,7 @@ jBluetoothClientSocket = class(jControl)
     procedure jFree();
     procedure SetDevice(_device: jObject);
     procedure SetUUID(_strUUID: string);
+    procedure SetSecureConnection(IsSecureConnection: Boolean); //by Tomash
     procedure Connect();  overload;
 
 
@@ -185,6 +186,12 @@ begin
   FUUID:= _strUUID;
   if FInitialized then
      jBluetoothClientSocket_SetUUID(FjEnv, FjObject, _strUUID);
+end;
+
+procedure jBluetoothClientSocket.SetSecureConnection(IsSecureConnection: Boolean); //by Tomash
+begin
+  if FInitialized then
+    jni_proc_z(FjEnv, FjObject, 'SetSecureConnection' , IsSecureConnection);
 end;
 
 function jBluetoothClientSocket.IsConnected(): boolean;
@@ -457,7 +464,6 @@ end;
 function jBluetoothClientSocket_ByteArrayToString(env: PJNIEnv; _jbluetoothclientsocket: JObject; var _byteArray: TDynArrayOfJByte): string;
 var
   jStr: JString;
-  jBoo: JBoolean;
   jParams: array[0..0] of jValue;
   jMethod: jMethodID=nil;
   jCls: jClass=nil;
@@ -471,13 +477,7 @@ begin
   jCls:= env^.GetObjectClass(env, _jbluetoothclientsocket);
   jMethod:= env^.GetMethodID(env, jCls, 'ByteArrayToString', '([B)Ljava/lang/String;');
   jStr:= env^.CallObjectMethodA(env, _jbluetoothclientsocket, jMethod, @jParams);
-  case jStr = nil of
-     True : Result:= '';
-     False: begin
-              jBoo:= JNI_False;
-              Result:= string( env^.GetStringUTFChars(env, jStr, @jBoo));
-            end;
-  end;
+  Result:= GetPStringAndDeleteLocalRef(env, jStr);
 env^.DeleteLocalRef(env,jParams[0].l);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/bluetoothserversocket.pas
+++ b/android_bridges/bluetoothserversocket.pas
@@ -486,7 +486,6 @@ end;
 function jBluetoothServerSocket_ByteArrayToString(env: PJNIEnv; _jbluetoothserversocket: JObject; var _byteArray: TDynArrayOfJByte): string;
 var
   jStr: JString;
-  jBoo: JBoolean;
   jParams: array[0..0] of jValue;
   jMethod: jMethodID=nil;
   jCls: jClass=nil;
@@ -500,13 +499,7 @@ begin
   jCls:= env^.GetObjectClass(env, _jbluetoothserversocket);
   jMethod:= env^.GetMethodID(env, jCls, 'ByteArrayToString', '([B)Ljava/lang/String;');
   jStr:= env^.CallObjectMethodA(env, _jbluetoothserversocket, jMethod, @jParams);
-  case jStr = nil of
-     True : Result:= '';
-     False: begin
-              jBoo:= JNI_False;
-              Result:= string( env^.GetStringUTFChars(env, jStr, @jBoo));
-            end;
-  end;
+  Result:= GetPStringAndDeleteLocalRef(env, jStr);
   env^.DeleteLocalRef(env,jParams[0].l);
   env^.DeleteLocalRef(env, jCls);
 end;

--- a/android_bridges/broadcastreceiver.pas
+++ b/android_bridges/broadcastreceiver.pas
@@ -297,23 +297,8 @@ end;
 
 
 function jBroadcastReceiver_GetResultData(env: PJNIEnv; _jbroadcastreceiver: JObject): string;
-var
-  jStr: JString;
-  jBoo: JBoolean;
-  jMethod: jMethodID=nil;
-  jCls: jClass=nil;
 begin
-  jCls:= env^.GetObjectClass(env, _jbroadcastreceiver);
-  jMethod:= env^.GetMethodID(env, jCls, 'GetResultData', '()Ljava/lang/String;');
-  jStr:= env^.CallObjectMethod(env, _jbroadcastreceiver, jMethod);
-  case jStr = nil of
-     True : Result:= '';
-     False: begin
-              jBoo:= JNI_False;
-              Result:= string( env^.GetStringUTFChars(env, jStr, @jBoo));
-            end;
-  end;
-  env^.DeleteLocalRef(env, jCls);
+  Result:= jni_func_out_t(env, _jbroadcastreceiver, 'GetResultData');
 end;
 
 

--- a/android_bridges/contextmenu.pas
+++ b/android_bridges/contextmenu.pas
@@ -39,6 +39,7 @@ jContextMenu = class(jControl)
     procedure UnCheckAllMenuItem();
     procedure RegisterForContextMenu(_view: jObject);
     procedure UnRegisterForContextMenu(_View: JObject); 
+    procedure OpenContextMenu(_view: jObject);
     function AddItem(_menu: jObject; _itemID: integer; _caption: string; _itemType: TMenuItemType): jObject;
     procedure SetHeader(_menu: jObject; _title: string; _headerIconIdentifier: string);
 
@@ -65,6 +66,7 @@ function jContextMenu_GetMenuItemByIndex(env: PJNIEnv; _jcontextmenu: JObject; _
 procedure jContextMenu_UnCheckAllMenuItem(env: PJNIEnv; _jcontextmenu: JObject);
 procedure jContextMenu_RegisterForContextMenu(env: PJNIEnv; _jcontextmenu: JObject; _view: jObject);
 procedure JContextMenu_UnRegisterForContextMenu(env: PJNIEnv; _JContextMenu: JObject; _View: JObject); 
+procedure JContextMenu_OpenContextMenu(env: PJNIEnv; _JContextMenu: JObject; _View: JObject);
 function jContextMenu_AddItem(env: PJNIEnv; _jcontextmenu: JObject; _menu: jObject; _itemID: integer; _caption: string; _itemType: integer): jObject;
 procedure jContextMenu_SetHeader(env: PJNIEnv; _jcontextmenu: JObject; _menu: jObject; _title: string; _headerIconIdentifier: string);
 
@@ -190,6 +192,14 @@ begin
 if(FInitialized) then 
   JContextMenu_UnRegisterForContextMenu(FjEnv, FjObject, _View); 
 end; 
+
+//by Tomash
+procedure jContextMenu.OpenContextMenu(_View: JObject);
+begin
+if(FInitialized) then
+  JContextMenu_OpenContextMenu(FjEnv, FjObject, _View);
+end;
+
 
 function jContextMenu.AddItem(_menu: jObject; _itemID: integer; _caption: string; _itemType: TMenuItemType): jObject;
 begin
@@ -388,6 +398,20 @@ begin
   env^.CallVoidMethodA(env, _JContextMenu, JMethod, @JParams);
   env^.DeleteLocalRef(env, jCls);
 end; 
+
+procedure JContextMenu_OpenContextMenu(env: PJNIEnv; _JContextMenu: JObject; _View: JObject);
+var
+  JParams: array[0..0] of JValue;
+  JMethod: JMethodID = nil;
+  JCls: JClass = nil;
+begin
+  JParams[0].l := _View;
+  JCls := env^.GetObjectClass(env, _JContextMenu);
+  JMethod := env^.GetMethodID(env, JCls, 'OpenContextMenu', '(Landroid/view/View;)V');
+  env^.CallVoidMethodA(env, _JContextMenu, JMethod, @JParams);
+  env^.DeleteLocalRef(env, jCls);
+end;
+
 
 function jContextMenu_AddItem(env: PJNIEnv; _jcontextmenu: JObject; _menu: jObject; _itemID: integer; _caption: string; _itemType: integer): jObject;
 var

--- a/android_bridges/dblistview.pas
+++ b/android_bridges/dblistview.pas
@@ -849,24 +849,8 @@ end;
 
 
 function jDBListView_GetItemCaption(env: PJNIEnv; _jdblistview: JObject): string;
-var
-  jStr: JString;
-  jBoo: JBoolean;
-  jMethod: jMethodID = nil;
-  jCls: jClass = nil;
 begin
-  jCls := env^.GetObjectClass(env, _jdblistview);
-  jMethod := env^.GetMethodID(env, jCls, 'GetItemCaption', '()Ljava/lang/String;');
-  jStr := env^.CallObjectMethod(env, _jdblistview, jMethod);
-  case jStr = nil of
-    True: Result := '';
-    False:
-    begin
-      jBoo := JNI_False;
-      Result := string(env^.GetStringUTFChars(env, jStr, @jBoo));
-    end;
-  end;
-  env^.DeleteLocalRef(env, jCls);
+  Result:= jni_func_out_t(env, _jdblistview, 'GetItemCaption');
 end;
 
 

--- a/android_bridges/intentmanager.pas
+++ b/android_bridges/intentmanager.pas
@@ -17,7 +17,7 @@ TIntentAction = (iaView, iaPick, iaSendto, idDial, iaCallbutton, iaCall, iaImage
 
 TIntentCategory = (icDefault, icLauncher, icHome, icInfo, icPreference, icAppBrowser,
                    icAppCalculator, icAppCalendar, icAppContacts, icAppEmail,
-                   icAppGallery, icAppMaps, icAppMessaging, icAppMusic);
+                   icAppGallery, icAppMaps, icAppMessaging, icAppMusic, icOpenable);
 
 TIntentFlag = (ifActivityNewTask, ifActivityBroughtToFront, ifActivityTaskOnHome,
                ifActivityForwardResult, ifActivityClearWhenTaskReset,

--- a/android_bridges/laz_and_controls_events.pas
+++ b/android_bridges/laz_and_controls_events.pas
@@ -587,6 +587,7 @@ var
  _jBoolean: JBoolean;
  keepConnected: boolean;
 begin
+  keepConnected := true;
   gApp.Jni.jEnv:= env;
   gApp.Jni.jThis:= this;
 
@@ -620,6 +621,7 @@ var
 
   keepConnected: boolean;
 begin
+  keepConnected := true;
   if byteArrayData <> nil then
   begin
      sizeArray:=  env^.GetArrayLength(env, byteArrayData);

--- a/android_bridges/spinner.pas
+++ b/android_bridges/spinner.pas
@@ -860,23 +860,8 @@ end;
 
 
 function jSpinner_getSelectedItem(env: PJNIEnv; _jspinner: JObject): string;
-var
-  jStr: JString;
-  jBoo: JBoolean;
-  jMethod: jMethodID=nil;
-  jCls: jClass=nil;
 begin
-  jCls:= env^.GetObjectClass(env, _jspinner);
-  jMethod:= env^.GetMethodID(env, jCls, 'GetSelectedItem', '()Ljava/lang/String;');
-  jStr:= env^.CallObjectMethod(env, _jspinner, jMethod);
-  case jStr = nil of
-     True : Result:= '';
-     False: begin
-              jBoo:= JNI_False;
-              Result:= string( env^.GetStringUTFChars(env, jStr, @jBoo));
-            end;
-  end;
-  env^.DeleteLocalRef(env, jCls);
+  Result:= jni_func_out_t(env, _jspinner, 'GetSelectedItem');
 end;
 
 procedure jSpinner_Clear(env: PJNIEnv; _JSpinner: JObject); 
@@ -1053,23 +1038,8 @@ begin
 end;
 
 function jSpinner_GetText(env: PJNIEnv; _jspinner: JObject): string;
-var
-  jStr: JString;
-  jBoo: JBoolean;
-  jMethod: jMethodID=nil;
-  jCls: jClass=nil;
 begin
-  jCls:= env^.GetObjectClass(env, _jspinner);
-  jMethod:= env^.GetMethodID(env, jCls, 'GetText', '()Ljava/lang/String;');
-  jStr:= env^.CallObjectMethod(env, _jspinner, jMethod);
-  case jStr = nil of
-     True : Result:= '';
-     False: begin
-              jBoo:= JNI_False;
-              Result:= string( env^.GetStringUTFChars(env, jStr, @jBoo));
-            end;
-  end;
-  env^.DeleteLocalRef(env, jCls);
+  Result:= jni_func_out_t(env, _jspinner, 'GetText');
 end;
 
 procedure jSpinner_SetText(env: PJNIEnv; _jspinner: JObject; _index: integer);
@@ -1128,25 +1098,8 @@ env^.DeleteLocalRef(env,jParams[1].l);
 end;
 
 function jSpinner_GetItemTagString(env: PJNIEnv; _jspinner: JObject; _index: integer): string;
-var
-  jStr: JString;
-  jBoo: JBoolean;
-  jParams: array[0..0] of jValue;
-  jMethod: jMethodID=nil;
-  jCls: jClass=nil;
 begin
-  jParams[0].i:= _index;
-  jCls:= env^.GetObjectClass(env, _jspinner);
-  jMethod:= env^.GetMethodID(env, jCls, 'GetItemTagString', '(I)Ljava/lang/String;');
-  jStr:= env^.CallObjectMethodA(env, _jspinner, jMethod, @jParams);
-  case jStr = nil of
-     True : Result:= '';
-     False: begin
-              jBoo:= JNI_False;
-              Result:= string( env^.GetStringUTFChars(env, jStr, @jBoo));
-            end;
-  end;
-  env^.DeleteLocalRef(env, jCls);
+  Result:= jni_func_i_out_t(env, _jspinner, 'GetItemTagString', _index);
 end;
 
 procedure jSpinner_SetItemTagString(env: PJNIEnv; _jspinner: JObject; _index: integer; _strTag: string);

--- a/android_bridges/treelistview.pas
+++ b/android_bridges/treelistview.pas
@@ -770,29 +770,8 @@ begin
 end;
 
 function jTreeListView_GetNodeData(env: PJNIEnv; _jtreelistview: JObject; id: integer): string;
-var
-  jParams: array[0..0] of jValue;
-  _jString : jString;
-  //_jBoolean: jBoolean;
-  jMethod: jMethodID=nil;
-  jCls: jClass=nil;
-  tmp: PChar;
 begin
-  jParams[0].i:= id;
-  jCls:= env^.GetObjectClass(env, _jtreelistview);
-  jMethod:= env^.GetMethodID(env, jCls, 'GetNodeData', '(I)Ljava/lang/String;');
-  _jString := env^.CallObjectMethodA(env, _jtreelistview, jMethod, @jParams);
-  case _jString = nil of
-   True : Result    := '';
-   False: begin
-           //_jBoolean := JNI_False;
-           tmp    := env^.GetStringUTFChars(env, _jString, nil);
-           Result := AnsiString( tmp );                       // Hopefully this creates a copy!
-           env^.ReleaseStringUTFChars(env, _jString, tmp);    // So now we can discard tmp   (see dalvik/vm/Jni.c)
-           env^.DeleteLocalRef(env, _jString);                // and then the java.lang.String
-          end;
-  end;
-  env^.DeleteLocalRef(env, jCls);
+  Result:= jni_func_i_out_t(env, _jtreelistview, 'GetNodeData', id);
 end;
 
 function jTreeListView_GetFirstChild(env: PJNIEnv; _jtreelistview: JObject; parent_id: integer): integer;

--- a/android_wizard/smartdesigner/java/App.java
+++ b/android_wizard/smartdesigner/java/App.java
@@ -264,12 +264,12 @@ private Controls       controls;
    public boolean onKeyDown(int keyCode, KeyEvent event) {
 	   
 	  char c = event.getDisplayLabel();	        
-	  //boolean mute = controls.jAppOnKeyDown(c,keyCode,KeyEvent.keyCodeToString(keyCode));  //TODO
-      //if (mute) return false;	  
+	  boolean mute = false;
+	  
       switch(keyCode) {
             
       case KeyEvent.KEYCODE_BACK:
-    	 boolean mute = controls.jAppOnKeyDown(c,keyCode,KeyEvent.keyCodeToString(keyCode));    	  
+    	 mute = controls.jAppOnKeyDown(c,keyCode,KeyEvent.keyCodeToString(keyCode));    	  
          if (!mute) { //continue ...
         	 onBackPressed();
              return true;
@@ -278,20 +278,20 @@ private Controls       controls;
          }
          
       case KeyEvent.KEYCODE_MENU:     	     	      	          
-    	 controls.jAppOnKeyDown(c,keyCode,KeyEvent.keyCodeToString(keyCode));
+    	 mute = controls.jAppOnKeyDown(c,keyCode,KeyEvent.keyCodeToString(keyCode));
          break;
               
         case KeyEvent.KEYCODE_SEARCH:
-          controls.jAppOnKeyDown(c,keyCode,KeyEvent.keyCodeToString(keyCode));
+          mute = controls.jAppOnKeyDown(c,keyCode,KeyEvent.keyCodeToString(keyCode));
           break;
                     
         case KeyEvent.KEYCODE_VOLUME_UP:
           //event.startTracking();  //TODO
-          controls.jAppOnKeyDown(c,keyCode,KeyEvent.keyCodeToString(keyCode));
+          mute = controls.jAppOnKeyDown(c,keyCode,KeyEvent.keyCodeToString(keyCode));
           break;
           
         case KeyEvent.KEYCODE_VOLUME_DOWN:
-          controls.jAppOnKeyDown(c,keyCode,KeyEvent.keyCodeToString(keyCode));
+          mute = controls.jAppOnKeyDown(c,keyCode,KeyEvent.keyCodeToString(keyCode));
           break;
           
           /*commented! need SDK API >= 18 [Android 4.3] to compile!*/
@@ -319,8 +319,15 @@ private Controls       controls;
         case KeyEvent.KEYCODE_NUM_LOCK:
             controls.jAppOnKeyDown(c,keyCode,KeyEvent.keyCodeToString(keyCode));
             break;            
-        //default:  controls.jAppOnKeyDown(c,keyCode,KeyEvent.keyCodeToString(keyCode));         	
+
+        default:  mute = controls.jAppOnKeyDown(c,keyCode,KeyEvent.keyCodeToString(keyCode));         	
       }      
-      return super.onKeyDown(keyCode, event);      
+
+      if (mute) 
+      {
+        	 return true;
+      } else {
+        	 return super.onKeyDown(keyCode, event);        	 
+      }       
    }        
 }

--- a/android_wizard/smartdesigner/java/jBluetooth.java
+++ b/android_wizard/smartdesigner/java/jBluetooth.java
@@ -124,9 +124,13 @@ public class jBluetooth /*extends ...*/ {
     public void Enabled(){
     	
     	if (mBA != null) {   //real device... 
-    	   Toast.makeText(controls.activity.getApplicationContext(),"Adapter: "+mBA.getName() ,Toast.LENGTH_LONG).show();    	
+    	   //Toast.makeText(controls.activity.getApplicationContext(),"Adapter: "+mBA.getName() ,Toast.LENGTH_LONG).show();    	
            if (!mBA.isEnabled()) {
-             controls.activity.startActivityForResult(new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE), 999);
+             try {
+			    mBA.enable();
+			  } catch (Exception e) {
+                controls.activity.startActivityForResult(new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE), 999);
+			 }
              //Toast.makeText(controls.activity.getApplicationContext(),"Bluetooth turned On" ,Toast.LENGTH_LONG).show();
              controls.pOnBluetoothEnabled(pascalObj);
            }          
@@ -216,7 +220,7 @@ public class jBluetooth /*extends ...*/ {
     //This method returns the current state of the Bluetooth Adapter.
     public int GetState() {
       if (mBA != null) {
-        return mBA.getState();  //STATE_OFF, STATE_TURNING_ON, STATE_ON, STATE_TURNING_OFF.
+        return mBA.getState();  //STATE_OFF=10, STATE_TURNING_ON=11, STATE_ON=12, STATE_TURNING_OFF=13.
       } else { 
     	  return -1;
       }
@@ -269,11 +273,11 @@ public class jBluetooth /*extends ...*/ {
     }
  
     public BluetoothDevice GetRemoteDeviceByAddress(String _deviceAddress){
-    	
-       if (IsReachablePairedDevice(_deviceAddress))	
+	    try {
           return mBA.getRemoteDevice(_deviceAddress);
-       else
+      	} catch (Exception e) {
     	  return null;
+	    }
     }
 
     public BluetoothDevice GetRemoteDevice(String _deviceAddress){

--- a/android_wizard/smartdesigner/java/jBluetoothServerSocket.java
+++ b/android_wizard/smartdesigner/java/jBluetoothServerSocket.java
@@ -496,11 +496,30 @@ public void SetTimeout(int _milliseconds) {
           	  if (bytes_read > 0) {	
                   bufferOutput.write(inputBuffer, 0, bytes_read);
                   publishProgress(bufferOutput);
+
+                try {                	 
+           	   		bufferOutput.close();    		
+  			     } catch (IOException e) {
+  					// TODO Auto-generated catch block
+  					e.printStackTrace();
+  			    }                
+                bufferOutput=null;       
+                  
+                  
           	  }
           	}
           }
                                   	                         
-        }// main loop            
+        }// main loop
+        
+            try {
+          	  if (bufferOutput != null)
+          	      bufferOutput.close();	
+				} catch (IOException e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+			  } 
+			             
         return null;
       }
       
@@ -512,7 +531,7 @@ public void SetTimeout(int _milliseconds) {
 		//http://examples.javacodegeeks.com/core-java/nio/bytebuffer/convert-between-bytebuffer-and-byte-array/
       @Override
       protected void onProgressUpdate(ByteArrayOutputStream...buffers) {
-         super.onProgressUpdate(buffers[0]);            
+         super.onProgressUpdate(buffers);            
 		   if (!flagAceept) {
 			   flagAceept = true;
 		       boolean keep = controls.pOnBluetoothServerSocketConnected(pascalObj,mConnectedSocket.getRemoteDevice().getName(),mConnectedSocket.getRemoteDevice().getAddress());
@@ -521,7 +540,6 @@ public void SetTimeout(int _milliseconds) {
 		    	    
 		    	    mBufferInput = null;
 					mBufferOutput = null;
-		  			mConnectedSocket = null;
 		  			
 		    		while (mConnectedSocket.isConnected()) {
 		    			try {
@@ -531,19 +549,15 @@ public void SetTimeout(int _milliseconds) {
 						e.printStackTrace();
 					    }   
 		    		}		    																	              		
+		    		
+		  			mConnectedSocket = null;
+		  			
 		       }	
 		   }  	
 		   
 		   if (IsFirstsByteHeader) { 			   
 		      if (buffers[0].toByteArray().length == lenContent) { 		    	  
                mConnected = controls.pOnBluetoothServerSocketIncomingData(pascalObj, buffers[0].toByteArray(), headerBuffer);
-               try {
-              	 if (bufferOutput != null) 
-              	   bufferOutput.close();                	   
-				 } catch (IOException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
-				 }                 
 		      }  
             //TODO
             /*
@@ -552,13 +566,6 @@ public void SetTimeout(int _milliseconds) {
 		   }        
          else {
       	  mConnected = controls.pOnBluetoothServerSocketIncomingData(pascalObj, buffers[0].toByteArray(), headerBuffer);
-            try {
-          	  if (bufferOutput != null)
-          	      bufferOutput.close();	
-				} catch (IOException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
-			  }              
          } 		    		   
       }
       

--- a/android_wizard/smartdesigner/java/jCanvas.java
+++ b/android_wizard/smartdesigner/java/jCanvas.java
@@ -102,6 +102,11 @@ public class jCanvas {
 		mTextPaint.setTextSize(scale*textsize);
 	}
 
+	//by Tomash
+    public void rotate(float rotation) {
+		mCanvas.rotate(rotation);
+	}
+
 	public  void setTypeface(int _typeface) {
 		Typeface t = null;
 		switch (_typeface) {

--- a/android_wizard/smartdesigner/java/jContextMenu.java
+++ b/android_wizard/smartdesigner/java/jContextMenu.java
@@ -107,6 +107,11 @@ public class jContextMenu /*extends ...*/ {
     public void UnRegisterForContextMenu(View _view){ 
       controls.activity.unregisterForContextMenu(_view); 
    }        
+
+	//by Tomash
+    public void OpenContextMenu(View _view){ 
+      controls.activity.openContextMenu(_view); 
+    }
  
     //_itemType --> 0:Default, 1:Checkable
     public MenuItem AddItem(ContextMenu _menu, int _itemID, String _caption, int _itemType){    	     	

--- a/android_wizard/smartdesigner/java/jDialogProgress.java
+++ b/android_wizard/smartdesigner/java/jDialogProgress.java
@@ -42,7 +42,17 @@ public class jDialogProgress {
 	  public void Show() {
 		if (dialog != null) dialog.dismiss();
 		dialog = null;	  
-		dialog = new ProgressDialog(controls.activity);
+		dialog = new ProgressDialog(controls.activity) {
+				//by Tomash
+				@Override
+                public void onBackPressed() {
+				  if (mCancelable) { 
+                  dialog.dismiss();
+
+		          }
+                  controls.pOnBackPressed(PasObj); // Pascal Event
+
+                }};
 		
 		if (!mMsg.equals("")) dialog.setMessage(mMsg);		 
 		if (!mTitle.equals("")) 
@@ -50,9 +60,9 @@ public class jDialogProgress {
 		 else 
 			dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
 		
-		if (mCancelable)
-	       dialog.setCancelable(true);
-	    else   
+//		if (mCancelable)
+//	       dialog.setCancelable(true);
+//	    else   
 	    	dialog.setCancelable(false);
 		
 	    dialog.show();

--- a/android_wizard/smartdesigner/java/jHttpClient.native
+++ b/android_wizard/smartdesigner/java/jHttpClient.native
@@ -1,4 +1,4 @@
-public native void pOnHttpClientContentResult(long pasobj, String content);
+public native void pOnHttpClientContentResult(long pasobj, byte[] content);
 public native void pOnHttpClientCodeResult(long pasobj, int code);
 public native void pOnHttpClientUploadProgress(long pasobj, long progress);
 public native void pOnHttpClientUploadFinished(long pasobj, int connectionStatusCode, String connectionStatusMessage, String fullFileName);

--- a/android_wizard/smartdesigner/java/jIntentManager.java
+++ b/android_wizard/smartdesigner/java/jIntentManager.java
@@ -611,7 +611,7 @@ Sending Data: Extras vs. URI Parameters
 	   	case 11: mIntent.addCategory(Intent.CATEGORY_APP_MAPS);	   	
 	   	case 12: mIntent.addCategory(Intent.CATEGORY_APP_MESSAGING);
 	   	case 13: mIntent.addCategory(Intent.CATEGORY_APP_MUSIC);
-
+	   	case 14: mIntent.addCategory(Intent.CATEGORY_OPENABLE); //by Tomash
 	  }		
    }
    

--- a/android_wizard/smartdesigner/java/jListView.java
+++ b/android_wizard/smartdesigner/java/jListView.java
@@ -1611,6 +1611,8 @@ public class jListView extends ListView {
 		setAdapter(aadapter);
 
 		setChoiceMode(ListView.CHOICE_MODE_SINGLE);
+		
+		setFastScrollEnabled(true); //by Tomash
 
 //fixed! thanks to @renabor
 		onItemClickListener = new OnItemClickListener() {

--- a/android_wizard/smartdesigner/java/jShareFile.java
+++ b/android_wizard/smartdesigner/java/jShareFile.java
@@ -183,7 +183,7 @@ public class jShareFile /*extends ...*/ {
   }
 	
 }
-
+/* Tomash: WTF?
 //by jmpessoa
 class CustomSpinnerArrayAdapter<T> extends ArrayAdapter<String>{
 	
@@ -286,6 +286,6 @@ public View getDropDownView(int position, View convertView, ViewGroup parent)
 	    	mTextFontSize = txtFontSize;	
 	    }
 	
-}
+}*/
 
 

--- a/android_wizard/smartdesigner/java/jView.java
+++ b/android_wizard/smartdesigner/java/jView.java
@@ -4,6 +4,7 @@ import java.io.FileOutputStream;
 
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
+import android.graphics.drawable.Drawable;
 import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
@@ -29,12 +30,33 @@ public class jView extends View {
 		//this.setWillNotDraw(false);  //fire onDraw ... thanks to tintinux
 	}
 
+	/* deprecated
 	public Bitmap getBitmap(){
 		this.setDrawingCacheEnabled(true);  //thanks to tintinux
 		Bitmap b = Bitmap.createBitmap(this.getDrawingCache());
 		this.setDrawingCacheEnabled(false);
 		return b;
 	}
+	*/
+
+	//updated by Tomash
+	public Bitmap getBitmap(){
+		try {
+ 	    	Bitmap bitmap = Bitmap.createBitmap(this.getWidth(), this.getHeight(), Bitmap.Config.ARGB_8888);
+  	    	Canvas canvas = new Canvas(bitmap);
+   			Drawable background = this.getBackground();
+    		if (background != null) {
+				background.draw(canvas);
+			}
+			this.draw(canvas);
+			return bitmap;
+		}
+		catch (Exception e) 
+		{
+			//Log.e("jView_getBitmap", "Exception: "+ e.toString() );
+			return null;
+		}			
+    }	
 
 	public void setLeftTopRightBottomWidthHeight(int _left, int _top, int _right, int _bottom, int _w, int _h) {
 		LAMWCommon.setLeftTopRightBottomWidthHeight(_left,_top,_right,_bottom,_w,_h);


### PR DESCRIPTION
androidwidget.pas
	new function: GetPStringAndDeleteLocalRef
	see:
	https://stackoverflow.com/questions/45681730/android-art-crash-with-error-jni-detected-error-in-application-jstring-is-an
	Functions that return String have been improved and refactored in androidwidet.pas, Laz_And_Controls.pas etc.

jForm
	new: CopyFileFromUri
	new: StartDefaultActivityForFile
	improvement: CopyFromAssetsToInternalAppStorage, CopyFromAssetsToEnvironmentDir - support for subfolders in Assets folder
	improvement: GetDeviceID return ANDROID ID if no GSM device

jCanvas
	new: SetRotation

jBitmap
	new: GetCanvas - Allow draw directly on jBitmap using jCanvas
	new: GetBitmapSizeFromFile - Check bitmap dimension without loading all image file
	improvement: GetImageFromFile - Safe loading large bitmaps

jHttpClient
	change:	OnHttpClientContentResult - uses RawByteString instead String - support for binary response from server

jBluetooth
	improvement: GetRemoteDeviceByAddress - works with paited and unpaired devices

jBluetoothClientSocket
	new: SetSecureConnection(IsSecureConnection: Boolean)
	many improvements, blocking calls moved to a separate thread, use of "fallback" function

jBluetoothServerSocket
	bugfixes

jContextMenu
	new: OpenContextMenu(_view: jObject);

jIntentManager
	improvement: icOpenable - new in TIntentCategory

jDialogProgress
	new: OnBackPressed event

jListView
	improvement: Add in java: setFastScrollEnabled(true); It must be when there are hundreds of items in the list. Maybe a new property?

jSqliteDataAcces
	revised, support for full database path in a non-standard location (restored - it worked in older versions)

jTcpClientSocket
	many improvements, blocking calls moved to AsyncTask

jView
	improvement: GetImage - obsolete java code removed

jShareFile
	unused code commented