### PR TITLE
hide methods for NumStars, Rating ans Step from Lazarus editor

### DIFF
--- a/android_bridges/ratingbar.pas
+++ b/android_bridges/ratingbar.pas
@@ -28,7 +28,14 @@ jRatingBar = class(jVisualControl)
     FOnRatingChanged: TOnRatingChanged;
     procedure SetVisible(Value: Boolean);
     procedure SetColor(Value: TARGBColorBridge); //background
-    
+
+    function GetRating(): single;
+    procedure SetRating(_rating: single);
+    procedure SetNumStars(_numStars: integer);
+    function GetNumStars(): integer;
+    function GetStepSize(): single;
+    procedure SetStepSize(_step: single);
+
  public
     constructor Create(AOwner: TComponent); override;
     destructor  Destroy; override;
@@ -50,12 +57,6 @@ jRatingBar = class(jVisualControl)
     procedure AddLParamsParentRule(_rule: integer);
     procedure SetLayoutAll(_idAnchor: integer);
     procedure ClearLayout();
-    function GetRating(): single;
-    procedure SetRating(_rating: single);
-    procedure SetNumStars(_numStars: integer);
-    function GetNumStars(): integer;
-    function GetStepSize(): single;
-    procedure SetStepSize(_step: single);
     procedure SetIsIndicator(_isIndicator: boolean);
     procedure SetMax(_max: integer);
     procedure SetLGravity(_value: TLayoutGravity);


### PR DESCRIPTION

The follow methods was moved from public to private so they don't appear in auto-completion if users enter **jRatingBar1.** on the editor.

```delphi
    function GetNumStars(): integer;
    procedure SetNumStars(_numStars: integer);
    function GetRating(): single;
    procedure SetRating(_rating: single);
    function GetStepSize(): single;
    procedure SetStepSize(_step: single);
```
Access is only from properties: 
jRatingBar1.**NumStars** , jRatingBar1.**Rating** and jRatingBar1.**Step**