### PR TITLE
Replacing "mkdir" with "mkdirs" [by ADiV]

### DIFF
--- a/android_wizard/smartdesigner/java/jImageFileManager.java
+++ b/android_wizard/smartdesigner/java/jImageFileManager.java
@@ -426,9 +426,7 @@ public class jImageFileManager /*extends ...*/ {
          
          mImageFile = new File(imagesDir);
          
-         if (!mImageFile.exists()) {
-        	 mImageFile.mkdir();
-         }
+         if (!mImageFile.exists()) mImageFile.mkdirs();        
          
          mImageFile = new File(imagesDir, fileName);
          

--- a/android_wizard/smartdesigner/java/jSqliteDataAccess.java
+++ b/android_wizard/smartdesigner/java/jSqliteDataAccess.java
@@ -497,7 +497,7 @@ class SQLiteAssetHelper extends SQLiteOpenHelper {
         try {
         	File file1 = new File(DB_PATH);
         	if(!file1.exists()){
-        		file1.mkdir();
+        		file1.mkdirs();
         	}
         	
         	File file = new File(DB_PATH + "/" + DATABASE_NAME);
@@ -565,7 +565,7 @@ class SQLiteAssetHelper extends SQLiteOpenHelper {
 
         try {
             File f = new File(DB_PATH + "/");
-            if (!f.exists()) { f.mkdir(); }
+            if (!f.exists()) { f.mkdirs(); }
             if (isZip) {
                 ZipInputStream zis = Utils.getFileFromZip(is);
                 if (zis == null) {


### PR DESCRIPTION
Replacing "mkdir" with "mkdirs" prevents certain path creation errors.