### PR TITLE
Update uimportcstuff.pas

### DIFF
--- a/ide_tools/uimportcstuff.pas
+++ b/ide_tools/uimportcstuff.pas
@@ -6,7 +6,8 @@ interface
 
 uses
   Classes, SysUtils, FileUtil, Forms, Controls, Graphics, Dialogs, StdCtrls,
-  Buttons, ComCtrls;
+  Buttons, ComCtrls,
+  IniFiles, LazIDEIntf, ProjectIntf;
 
 type
 
@@ -17,6 +18,8 @@ type
     BitBtn2: TBitBtn;
     CheckBoxAllC: TCheckBox;
     CheckBoxAllH: TCheckBox;
+    AndroidmkComboBox: TComboBox;
+    h2pasComboBox: TComboBox;
     EditLibName: TEdit;
     EditImportC: TEdit;
     EditImportH: TEdit;
@@ -31,6 +34,7 @@ type
     SpeedButton3: TSpeedButton;
     SpeedButton4: TSpeedButton;
     StatusBar1: TStatusBar;
+    procedure FormShow(Sender: TObject);
     procedure SpeedButton1Click(Sender: TObject);
     procedure SpeedButton3Click(Sender: TObject);
   private
@@ -55,6 +59,44 @@ begin
   begin
     EditImportC.Text:= SelectDirectoryDialog1.FileName;
   end;
+end;
+
+procedure TFormImportCStuff.FormShow(Sender: TObject);
+
+var
+  Project: TLazProject;
+  pathToProject: string;
+  p: integer;
+
+
+begin
+
+   Left := (Screen.Width - Width) div 2;
+   Top := (Screen.Height - Height) div 2;
+
+   Project:= LazarusIDE.ActiveProject;
+
+  if Assigned(Project) and (Project.CustomData.Values['LAMW'] <> '' ) then
+  begin
+
+   p:= Pos(DirectorySeparator+'jni', Project.ProjectInfoFile);
+   pathToProject:= Copy(Project.ProjectInfoFile, 1, p);
+
+   with TIniFile.Create(pathToProject+'jni'+DirectorySeparator + 'ImportCStuff.ini') do
+   try
+     FormImportCStuff.EditImportC.Text := ReadString('ImportCStuff','EditImportC', '');
+     FormImportCStuff.CheckBoxAllC.Checked := ReadBool('ImportCStuff','CheckBoxAllC', False);
+     FormImportCStuff.EditImportH.Text := ReadString('ImportCStuff','EditImportH', '');
+     FormImportCStuff.CheckBoxAllH.Checked := ReadBool('ImportCStuff','CheckBoxAllH', False);
+     FormImportCStuff.EditLibName.Text := ReadString('ImportCStuff','EditLibName', '');
+     FormImportCStuff.AndroidmkComboBox.ItemIndex := ReadInteger('ImportCStuff','AndroidmkComboBox', 0);
+     FormImportCStuff.h2pasComboBox.ItemIndex := ReadInteger('ImportCStuff','h2pasComboBox', 0);
+   finally
+     Free;
+   end;
+
+  end;
+
 end;
 
 procedure TFormImportCStuff.SpeedButton3Click(Sender: TObject);


### PR DESCRIPTION
The update for “Use/Import C stuff” plugin:
1) Originally “Use/Import C stuff” plugin was able to compile C code only for armeabi-v7a.
Now it compiles for all platforms: armeabi-v7a, arm64-v8a, x86, x86_64.
2) “Use/Import C stuff” now saves current project’s settings in file “.\jni\ImportCStuff.ini “.
3) Added options for disabling “Android.mk” and “*.pp” file generation.

The update is in 3 files: 
amw_ide_menu_items.pas
uimportcstuff.pas
uimportcstuff.lfm
