### PR TITLE
Update Controls.java

### DIFF
--- a/android_wizard/smartdesigner/java/Controls.java
+++ b/android_wizard/smartdesigner/java/Controls.java
@@ -926,9 +926,9 @@ public  int Image_getWH (String filename ) {
       if (email == null) {
         return;
       }
-      email.putExtra(Intent.EXTRA_EMAIL, to);
-      email.putExtra(Intent.EXTRA_CC, cc);
-      email.putExtra(Intent.EXTRA_BCC, bcc);
+      email.putExtra(Intent.EXTRA_EMAIL, new String[]{to});
+      email.putExtra(Intent.EXTRA_CC, new String[]{cc});
+      email.putExtra(Intent.EXTRA_BCC, new String[]{bcc});
       email.putExtra(Intent.EXTRA_SUBJECT, subject);
       email.putExtra(Intent.EXTRA_TEXT, message);
       // Use email client only


### PR DESCRIPTION
Function jSend_Email fails to pass TO, CC, BCC email addresses, because email addresses must be provided as String array. This bug was fixed. 
The source:
---------------
https://stackoverflow.com/questions/3470042/intent-uri-to-launch-gmail-app
intent.putExtra(Intent.EXTRA_EMAIL, new String[] { "test@gmail.com" });
---------------