### PR TITLE
Update to support Gradle 4.1.0 [by ADiV]

### DIFF
--- a/android_wizard/androidwizard_intf.pas
+++ b/android_wizard/androidwizard_intf.pas
@@ -1889,7 +1889,8 @@ begin
                strList.Add('    package="'+FPackagePrefaceName+'.'+LowerCase(FSmallProjName)+'"');
                strList.Add('    android:versionCode="1"');
                strList.Add('    android:versionName="1.0" >');
-               strList.Add('    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="29"/>');
+               // Gradle not need minSdkVersion
+               strList.Add('    <uses-sdk android:targetSdkVersion="29"/>');
                strList.Add('    <application');
                strList.Add('        android:allowBackup="true"');
                strList.Add('        android:icon="@drawable/ic_launcher"');

--- a/android_wizard/smartdesigner/java/Controls.java
+++ b/android_wizard/smartdesigner/java/Controls.java
@@ -1047,13 +1047,27 @@ public  int Image_getWH (String filename ) {
 
     Cursor phones = this.activity.getContentResolver().query(ContactsContract.CommonDataKinds.Phone.CONTENT_URI, null, null, null, null);
     
-    if (phones == null) return "";    
+    if (phones == null) return "";
+    
+    String name = "";
+    String phoneNumber = "";
+    String phoneType = "";
+    int iColum = 0;
 
-    while (phones.moveToNext()) {
-      String name = phones.getString(phones.getColumnIndex(ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME));
-      String phoneNumber = phones.getString(phones.getColumnIndex(ContactsContract.CommonDataKinds.Phone.NUMBER));
-      String phoneType = phones.getString(phones.getColumnIndex(ContactsContract.CommonDataKinds.Phone.TYPE));
-
+    while (phones.moveToNext()) {           
+      name = "";
+      phoneNumber = "";
+      phoneType = "";
+      
+      iColum = phones.getColumnIndex(ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME);
+      if(iColum >= 0) name = phones.getString(iColum);
+      
+      iColum = phones.getColumnIndex(ContactsContract.CommonDataKinds.Phone.NUMBER);
+      if(iColum >= 0) phoneNumber = phones.getString(iColum);
+      
+      iColum = phones.getColumnIndex(ContactsContract.CommonDataKinds.Phone.TYPE);
+      if(iColum >= 0) phoneType = phones.getString(iColum);
+           
       name = name.toLowerCase();
 
       if (name.equals(username)) {
@@ -1077,15 +1091,27 @@ public  int Image_getWH (String filename ) {
     
     if (phones == null) return "";
     
+    String name = "";    
+    String phoneType = "";
+    int iColum = 0;
+    
     while (phones.moveToNext()) {
-      String name = phones.getString(phones.getColumnIndex(ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME));
-      String phoneType = phones.getString(phones.getColumnIndex(ContactsContract.CommonDataKinds.Phone.TYPE));
+    	name = "";        
+        phoneType = "";
+        
+        iColum = phones.getColumnIndex(ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME);
+        if(iColum >= 0) name = phones.getString(iColum);                
+        
+        iColum = phones.getColumnIndex(ContactsContract.CommonDataKinds.Phone.TYPE);
+        if(iColum >= 0) phoneType = phones.getString(iColum);
 
-      if (phoneType.equals("2")) { //mobile
-        nameList = nameList + delimiter + name;
+        if (phoneType.equals("2")) { //mobile
+         nameList = nameList + delimiter + name;
       }
     }
+    
     phones.close();
+    
     return nameList;
   }
 

--- a/android_wizard/smartdesigner/java/jForm.java
+++ b/android_wizard/smartdesigner/java/jForm.java
@@ -195,11 +195,12 @@ public class jForm {
 
         layout = new RelativeLayout(controls.activity);
 
-        if (layout == null) return;
-        
+        if (layout == null) {
+            return;
+        }
+
         layparam = new LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-                                    ViewGroup.LayoutParams.MATCH_PARENT);
-        
+                ViewGroup.LayoutParams.MATCH_PARENT);
         layout.setLayoutParams(layparam);
 
         mClipBoard = (ClipboardManager) controls.activity.getSystemService(Context.CLIPBOARD_SERVICE);
@@ -1298,19 +1299,18 @@ public class jForm {
 
             if (telephony == null) return "";            
 
-            devid = telephony.getDeviceId();
+            // Need system app - android.permission.READ_PRIVILIGED_PHONE_STATE
+            //devid = telephony.getDeviceId();
 
-            if (devid == null) return "";            
+            if (devid == "") return "";            
 
-            if (devid == "") 
-                devid = Secure.getString(this.controls.activity.getContentResolver(), Secure.ANDROID_ID);            
+            if (devid == "")             
+        	 devid = Secure.getString(this.controls.activity.getContentResolver(), Secure.ANDROID_ID);            
 
         } catch (SecurityException e) //ExceptionExceptionException
         {
             e.printStackTrace();
-        }
-
-        if (devid == null) return "";
+        }        
 
         return devid;
     }
@@ -2219,7 +2219,8 @@ public class jForm {
 
         //if (recentTask.get(i).baseActivity.toShortString().indexOf(this.controls.activity.getPackageName()) > -1) {
 
-        am.moveTaskToFront(controls.activity.getTaskId(), 0);
+        // Need system app - android.permission.REORDER_TASKS
+        //am.moveTaskToFront(controls.activity.getTaskId(), 0);
 
         //}
         //}
@@ -2827,7 +2828,10 @@ public class jForm {
 
                            // Note it's called "Display Name". This is
                            // provider-specific, and might not necessarily be the file name.
-                           String displayName = cursor.getString(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME));
+                           String displayName = "";
+                           
+                           int iColum = cursor.getColumnIndex(ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME);
+                           if(iColum >= 0) displayName = cursor.getString(iColum);
 
                            int sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE);
                             // If the size is unknown, the value stored is null. But because an
@@ -3193,7 +3197,7 @@ public class jForm {
 
     //Android 11:
     public String GetFileNameByUri(Uri uri) {
-        String result = null;
+        String result = "";
         
         final ContentResolver resolver = controls.activity.getContentResolver();
         
@@ -3203,7 +3207,8 @@ public class jForm {
             Cursor cursor = resolver.query(uri, null, null, null, null);
             try {
                 if (cursor != null && cursor.moveToFirst()) {
-                    result = cursor.getString(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME));
+                	int iColum = cursor.getColumnIndex(ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME);
+                    if(iColum >= 0) result = cursor.getString(iColum);                    
                 }
             } finally {
                 if (cursor != null) {


### PR DESCRIPTION
With this update we will be able to use the minimum Gradle 4.1.0 plugin recommended by Google and we will be able to activate the native debugging code.

In an already created app we need to remove android:minSdkVersion="16" from "AndroidManifest.xml" which is not necessary in gradle since we use build.gradle. If it is not deleted, it generates a compilation error. Then "Clean and Build" and "Build Android Apk"

Update to support Gradle 4.1.0:
classpath 'com.android.tools.build:gradle:4.1.0'
ndk { debugSymbolLevel 'FULL' }