### PR TITLE
Update jWebView.java

### DIFF
--- a/android_wizard/smartdesigner/java/jWebView.java
+++ b/android_wizard/smartdesigner/java/jWebView.java
@@ -445,7 +445,7 @@ public class jWebView extends WebView {
     }
 
     public void SetAppCacheEnabled(boolean _cacheEnabled) {
-        this.getSettings().setAppCacheEnabled(_cacheEnabled);
+//        this.getSettings().setAppCacheEnabled(_cacheEnabled);  // Application Cache API is deprecated, does not compile in Target SDK 33
     }
 
     public void SetDisplayZoomControls(boolean _displayZoomControls) {


### PR DESCRIPTION
Application Cache API is deprecated, does not compile in Target SDK 33.
See pages:
---------------------
https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/webkit/WebSettings.java
    /**
     * Sets whether the Application Caches API should be enabled. The default
     * is {@code false}. Note that in order for the Application Caches API to be
     * enabled, a valid database path must also be supplied to
     * {@link #setAppCachePath}.
     *
     * @param flag {@code true} if the WebView should enable Application Caches
     * @deprecated The Application Cache API is deprecated and this method will
     *             become a no-op on all Android versions once support is
     *             removed in Chromium. Consider using Service Workers instead.
     *             See https://web.dev/appcache-removal/ for more information.
     */
    public abstract void setAppCacheEnabled(boolean flag);
---------------------
https://github.com/pichillilorenzo/flutter_inappwebview/issues/1223
Build failed on Android Target SDK 33
<...>
cannot find symbol
settings.setAppCacheEnabled(false);
---------------------