### PR TITLE
Update jForm.java

### DIFF
--- a/android_wizard/smartdesigner/java/jForm.java
+++ b/android_wizard/smartdesigner/java/jForm.java
@@ -3248,7 +3248,7 @@ public class jForm {
             Cursor cursor = resolver.query(uri, null, null, null, null);
             try {
                 if (cursor != null && cursor.moveToFirst()) {
-                	int iColum = cursor.getColumnIndex(ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME);
+                	int iColum = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
                     if(iColum >= 0) result = cursor.getString(iColum);                    
                 }
             } finally {


### PR DESCRIPTION
Somebody has made the error when updating jForm.java file - the argument ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME
has nothing to do with Filename, and the result is that function GetFileNameByUri does not work anymore.
Restored back to original argument OpenableColumns.DISPLAY_NAME, now function GetFileNameByUri works as expected.