### PR TITLE
Update androidwidget.pas

### DIFF
--- a/android_bridges/androidwidget.pas
+++ b/android_bridges/androidwidget.pas
@@ -1302,7 +1302,10 @@ type
     function  GetJavaLastId(): integer; // by ADiV
     function  GetScreenSize(): string;
     function  GetScreenDensity(): string; overload;
+    function  GetScreenRealSizeInInches(): double;
     function  GetScreenDpi(): integer;
+    function  GetScreenRealXdpi(): double;
+    function  GetScreenRealYdpi(): double;    
     function  GetScreenDensity(strDensity: string): integer; overload;
     procedure SetDensityAssets( _value : TDensityAssets ); // by ADiV
 
@@ -4216,6 +4219,22 @@ begin
    Result:= jni_func_out_i(gapp.Jni.jEnv, FjObject, 'GetScreenDpi');
 end;
 
+function jForm.GetScreenRealXdpi(): double;
+begin
+  result := 0.0;
+  //in designing component state: result value here...
+  if FInitialized then
+   Result:= jni_func_out_d(gapp.Jni.jEnv, FjObject, 'GetScreenRealXdpi');
+end;
+
+function jForm.GetScreenRealYdpi(): double;
+begin
+  result := 0.0;
+  //in designing component state: result value here...
+  if FInitialized then
+   Result:= jni_func_out_d(gapp.Jni.jEnv, FjObject, 'GetScreenRealYdpi');
+end;
+
 function jForm.GetScreenDensity(): string;
 begin
   result := '';
@@ -4239,6 +4258,14 @@ begin
   //in designing component state: result value here...
   if FInitialized then
    Result:= jni_func_out_t(gapp.Jni.jEnv, FjObject, 'GetScreenSize');
+end;
+
+function jForm.GetScreenRealSizeInInches(): double;
+begin
+  result := 0.0;
+  //in designing component state: result value here...
+  if FInitialized then
+   Result:= jni_func_out_d(gapp.Jni.jEnv, FjObject, 'GetScreenRealSizeInInches');
 end;
 
 procedure jForm.LogDebug(_tag: string; _msg: string);


### PR DESCRIPTION
Added new functions for getting real screen size in inches and real pixel density.
Previous functions get only rough approximation of pixel density, which is not suitable for many applications.
As for example:
Self.GetScreenDpi() for Samsung Galaxy Tab A 10.1 (2016) SM-T580 reports 240 ppi, while actually it is ~224 ppi;
 Self.GetScreenDpi() for Samsung Galaxy S9 reports 640 ppi, while actually it is ~570 ppi.
Source info:
https://stackoverflow.com/questions/3166501/getting-the-screen-density-programmatically-in-android
Though Android doesn't use a direct pixel mapping, it uses a handful of quantized Density Independent Pixel values then scales to the actual screen size.
So the metrics.densityDpi property will be one of the DENSITY_xxx constants (120, 160, 213, 240, 320, 480 or 640 dpi).
If you need the actual lcd pixel density (perhaps for an OpenGL app) you can get it from the metrics.xdpi and metrics.ydpi properties for horizontal and vertical density respectively.