### PR TITLE
Update jForm.java

### DIFF
--- a/android_wizard/smartdesigner/java/jForm.java
+++ b/android_wizard/smartdesigner/java/jForm.java
@@ -92,6 +92,7 @@ import android.widget.RelativeLayout;
 import android.widget.Toast;
 import java.io.*;
 import java.lang.Class;
+import java.lang.Math;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.text.SimpleDateFormat;
@@ -1656,7 +1657,27 @@ public class jForm {
         controls.activity.getWindowManager().getDefaultDisplay().getMetrics(metrics);
         return metrics.densityDpi;
     }
-
+    
+    public double GetScreenRealXdpi() {
+        double r = 0.0;
+        DisplayMetrics metrics = new DisplayMetrics();
+        if (metrics == null) {
+            return 0;
+        }
+        controls.activity.getWindowManager().getDefaultDisplay().getMetrics(metrics);
+        return metrics.xdpi;
+    }
+    
+    public double GetScreenRealYdpi() {
+        double r = 0.0;
+        DisplayMetrics metrics = new DisplayMetrics();
+        if (metrics == null) {
+            return 0;
+        }
+        controls.activity.getWindowManager().getDefaultDisplay().getMetrics(metrics);
+        return metrics.ydpi;
+    }  	
+	
     public String GetScreenDensity() {
         String r = "";
         DisplayMetrics metrics = new DisplayMetrics();
@@ -2525,6 +2546,22 @@ public class jForm {
         return displaymetrics.heightPixels;
     }
 
+    public double GetScreenRealSizeInInches() {
+        double r = 0.0;
+        double screen_width = 0.0;
+        double screen_height = 0.0;
+
+        if(GetScreenRealXdpi() != 0)
+        {screen_width = GetRealScreenWidth() / GetScreenRealXdpi();}
+		
+        if(GetScreenRealYdpi() != 0)
+        screen_height = GetRealScreenHeight() / GetScreenRealYdpi();		
+		
+        r = Math.sqrt(screen_width*screen_width + screen_height*screen_height);	
+		
+        return r;
+    } 	
+	
     //by ADiV
     public String GetSystemVersionString() {
         return android.os.Build.VERSION.RELEASE;


### PR DESCRIPTION
Added new functions for getting real screen size in inches and real pixel density.
Previous functions get only rough approximation of pixel density, which is not suitable for many applications.
As for example:
Self.GetScreenDpi() for Samsung Galaxy Tab A 10.1 (2016) SM-T580 reports 240 ppi, while actually it is ~224 ppi;
 Self.GetScreenDpi() for Samsung Galaxy S9 reports 640 ppi, while actually it is ~570 ppi.
Source info:
https://stackoverflow.com/questions/3166501/getting-the-screen-density-programmatically-in-android
Though Android doesn't use a direct pixel mapping, it uses a handful of quantized Density Independent Pixel values then scales to the actual screen size.
So the metrics.densityDpi property will be one of the DENSITY_xxx constants (120, 160, 213, 240, 320, 480 or 640 dpi).
If you need the actual lcd pixel density (perhaps for an OpenGL app) you can get it from the metrics.xdpi and metrics.ydpi properties for horizontal and vertical density respectively.