### PR TITLE
Update androidprojoptions.pas

### DIFF
--- a/ide_tools/androidprojoptions.pas
+++ b/ide_tools/androidprojoptions.pas
@@ -507,7 +507,7 @@ begin
   includeList.Add(''''+cpuTarget+''''); //initial  Instruction Set
 
   PathToAndroidProject:= ExtractFilePath(FFileName);
-  TargetBuildFileName := 'lib' + ExtractFileName(LazarusIDE.ActiveProject.LazCompilerOptions.TargetFilename) + '.so';
+  TargetBuildFileName := ExtractFileName(LazarusIDE.ActiveProject.LazCompilerOptions.CreateTargetFilename);
 
   if FileExists(pathToAndroidProject + 'libs\armeabi\' + TargetBuildFileName ) then
   begin


### PR DESCRIPTION
Hi, 
Getting the filename from "TargetFilename" is not reliable (it can be empty or not begin with "lib" and ends with ".so" the current solution work but if the filename is already begin with "lib" and ends with ".so" fails to get the correct filename...
so, I investigated and found "CreateTargetFilename" is more reable and it return the correct filename without need to adding "lib" and "so"...