### PR TITLE
Update smartdesigner.pas

### DIFF
--- a/android_wizard/smartdesigner.pas
+++ b/android_wizard/smartdesigner.pas
@@ -1218,7 +1218,7 @@ begin
            auxStr := ExtractFileName(auxStr);
          end;
 
-         TargetBuildFileName := ExtractFileName(LazarusIDE.ActiveProject.LazCompilerOptions.TargetFilename);
+         TargetBuildFileName := ExtractFileName(LazarusIDE.ActiveProject.LazCompilerOptions.CreateTargetFilename);
          includeList:= TStringList.Create;
          includeList.Delimiter:= ',';
          includeList.StrictDelimiter:= True;

--- a/android_wizard/smartdesigner.pas
+++ b/android_wizard/smartdesigner.pas
@@ -1218,7 +1218,7 @@ begin
            auxStr := ExtractFileName(auxStr);
          end;
 
-         TargetBuildFileName := 'lib' + ExtractFileName(LazarusIDE.ActiveProject.LazCompilerOptions.TargetFilename) + '.so';
+         TargetBuildFileName := ExtractFileName(LazarusIDE.ActiveProject.LazCompilerOptions.TargetFilename);
          includeList:= TStringList.Create;
          includeList.Delimiter:= ',';
          includeList.StrictDelimiter:= True;


### PR DESCRIPTION
Hi, 
Getting the filename from "TargetFilename" is not reliable (it can be empty or not begin with "lib" and ends with ".so" the current solution work but if the filename is already begin with "lib" and ends with ".so" fails to get the correct filename...
so, I investigated and found "CreateTargetFilename" is more reable and it return the correct filename without need to adding "lib" and "so"...