### PR TITLE
Fix two issues with jBitmap.LoadFromFile method

### DIFF
--- a/android_bridges/Laz_And_Controls.pas
+++ b/android_bridges/Laz_And_Controls.pas
@@ -12398,6 +12398,7 @@ end;
 procedure jBitmap.LoadFromFile(fullFileName: string);
 var
   path: string;
+  knownDir: string;
 begin
   if FInitialized then
   begin
@@ -12426,18 +12427,26 @@ begin
         FFilePath := fpathExt;
       end;
 
-      if path <> '' then FImageName := ExtractFileName(fullFileName)
+      if path <> '' then
+      begin
+        knownDir:=GetFilePath(FFilePath) + '/';
+        FImageName := Copy(fullFileName, length(knownDir) + 1, length(fullFileName) - length(knownDir));//ExtractFileName(fullFileName)
+      end
       else
+      begin
+        knownDir:='';
         FImageName := fullFileName;
+      end;
 
       jni_proc_t(gApp.jni.jEnv, FjObject, 'loadFile',
-        GetFilePath(FFilePath) + '/' + FImageName);
+         knownDir + FImageName);
 
-      FWidth := jni_func_out_i(gApp.jni.jEnv, FjObject, 'GetWidth');
-      FHeight := jni_func_out_i(gApp.jni.jEnv, FjObject, 'GetHeight');
+      _FWidth := jni_func_out_i(gApp.jni.jEnv, FjObject, 'GetWidth');
+      _FHeight := jni_func_out_i(gApp.jni.jEnv, FjObject, 'GetHeight');
     end;
   end;
 end;
+
 
 procedure jBitmap.LoadFromRes(imgResIdentifier: string);  // ..res/drawable
 begin

--- a/android_bridges/Laz_And_Controls.pas
+++ b/android_bridges/Laz_And_Controls.pas
@@ -12430,7 +12430,7 @@ begin
       if path <> '' then
       begin
         knownDir:=GetFilePath(FFilePath) + '/';
-        FImageName := Copy(fullFileName, length(knownDir) + 1, length(fullFileName) - length(knownDir));//ExtractFileName(fullFileName)
+        FImageName := Copy(fullFileName, length(knownDir) + 1, length(fullFileName) - length(knownDir));
       end
       else
       begin
@@ -12441,8 +12441,8 @@ begin
       jni_proc_t(gApp.jni.jEnv, FjObject, 'loadFile',
          knownDir + FImageName);
 
-      _FWidth := jni_func_out_i(gApp.jni.jEnv, FjObject, 'GetWidth');
-      _FHeight := jni_func_out_i(gApp.jni.jEnv, FjObject, 'GetHeight');
+      FWidth := jni_func_out_i(gApp.jni.jEnv, FjObject, 'GetWidth');
+      FHeight := jni_func_out_i(gApp.jni.jEnv, FjObject, 'GetHeight');
     end;
   end;
 end;


### PR DESCRIPTION
This patch tries to solve two issues with the `jBitmap.LoadFromFile` method.
- Without it, it's impossible to correctly load a file when it's in some of the subfolders of the known folder. For example, if I would like to load `/storage/emulated/0/myrootfolder/mysubfolder/myfile.jpg`, the current (incorrect) implementation will try to load `/storage/emulated/0/myfile.jpg` since the ExtractFileName would ignore the subfolder part. In case of this example, the final value for `FImageName` will be `myrootfolder/mysubfolder/myfile.jpg`. Probably this is not technically "image name", but it's correct to always restore the file location from the field data.
- In case `fullFileName` is not recognized, the current version (incorrect) will force leading slash. So if I pass `/someaccessiblefolder/somefile.jpg`, the current implementation won't find a known directory in this path and will pass `//someaccessiblefolder/somefile.jpg` to jni. So, this commit addresses also this issue.

The change with underscore symbol for FWidth, FHeight (visible in diff) is because while testing I dealt with an older implementation of jBitmap when the fields were called differently. 