### PR TITLE
Update androidprojoptions.pas

### DIFF
--- a/ide_tools/androidprojoptions.pas
+++ b/ide_tools/androidprojoptions.pas
@@ -1816,8 +1816,9 @@ begin
   if cbIndex >= 0 then
     cbChipset.ItemIndex := cbIndex;
 
-  CheckBoxSupport.Checked:=(LazarusIDE.ActiveProject.CustomData['Support']='TRUE');
-
+  //CheckBoxSupport.Checked:=(LazarusIDE.ActiveProject.CustomData['Support']='TRUE');
+  CheckBoxSupport.Checked := true;
+  
   FMinSdk       := proj.CustomData['MinSdk'];
   FTargetSdk    := proj.CustomData['TargetSdk'];
   FAndroidTheme := proj.CustomData['Theme'];


### PR DESCRIPTION
I believe that the
[LAMW]Android Project Option -> Android Manifest -> Add Support Library
It always has to be activated, because if it is False, it will give an error when adding a button, for example.

Or are there cases where it is necessary to leave false??